### PR TITLE
feat(average-sentiment-calculation): Added feature to calculate the average sentiment of the JSON file provided

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,21 @@ const calcAverageSentiment = (sentimentScores) => {
         averageSentiment = score.plus(averageSentiment)
     );
 
-    return averageSentiment.dividedBy(scoresAmt).toFixed();
+    return averageSentiment.dividedBy(scoresAmt);
+}
+
+/**
+ * Returns the vote of a sentiment score, whether or not a computed
+ * sentiment was neutral, positive, or negative, based on senticon scoring,
+ * the lexicon scoring system used by the SentimentManager to compute
+ * sentiment per message
+ * @param {BigNumber} sentimentScore A sentiment score
+ * @returns {string} The vote of the score based on senticon scoring
+ */
+const getSentimentVote = (sentimentScore) => {
+    if (sentimentScore.isEqualTo(0)) return "neutral";
+
+    return sentimentScore.isGreaterThan(0) ? "postive" : "negative";
 }
 
 // Main Driver
@@ -97,6 +111,7 @@ const calcAverageSentiment = (sentimentScores) => {
 
     feedbackStream
         .on("close", () => {
-            console.log(calcAverageSentiment(sentimentScores));
+            const averageSentiment = calcAverageSentiment(sentimentScores);
+            console.log(`Average sentiment of dataset is ${getSentimentVote(averageSentiment)} with a score of ${averageSentiment.toFixed()}`);
         })
 })();

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@ const path = require("path");
 const JSONStream = require("JSONStream");
 const { SentimentManager } = require("node-nlp");
 const { createWorker } = require("tesseract.js");
-
+const { default: BigNumber } = require("bignumber.js");
 
 // File Utils
 /**
@@ -12,6 +12,29 @@ const { createWorker } = require("tesseract.js");
  */
 const isJson = (file) => {
     return path.extname(file).toLowerCase() === ".json";
+}
+
+// Sentiment Analysis Utils
+/**
+ * @param {BigNumber[]} sentimentScores An array of computed sentiment
+ * scores from the JSON file of feedback
+ * @returns {BigNumber} The average sentiment of the sentimentScores
+ */
+const calcAverageSentiment = (sentimentScores) => {
+    const scoresAmt = sentimentScores.length;
+
+    // Avoids divide by 0 error
+    if (scoresAmt === 0) {
+        return 0;
+    }
+
+    let averageSentiment = new BigNumber(0);
+
+    sentimentScores.forEach(score => 
+        averageSentiment = score.plus(averageSentiment)
+    );
+
+    return averageSentiment.dividedBy(scoresAmt).toFixed();
 }
 
 // Main Driver
@@ -47,23 +70,33 @@ const isJson = (file) => {
             `File ${feedbackJsonFile} does not exist, please pass a valid file`
         );
         } else {
-        console.log(error);
+            console.log(error);
         }
     });
+
+    const sentimentScores = [];
 
     const sentiment = new SentimentManager();
 
     // Assumes the main JSON will only have a singular member which will
     // be structured as an array of all feedback entries, wherein the
     // user's written feedback will be in a member called "feedback"
-    feedbackStream.pipe(JSONStream.parse("*")).on("data", (chunk) => {
-        chunk.forEach((feedbackEntry) => {
-        sentiment.process("en", feedbackEntry.feedback).then((result) =>
-            console.log({
-            ...feedbackEntry,
-            sentiment_analysis: result,
-            })
-        );
+    feedbackStream.pipe(JSONStream.parse("*"))
+        .on("data", chunk => {
+            chunk.forEach(feedbackEntry => {
+                sentiment.process("en", feedbackEntry.feedback).then(result => {
+                    sentimentScores.push(new BigNumber(result.score));
+
+                    console.log({
+                        ...feedbackEntry,
+                        sentiment_analysis: result
+                    });
+                });
+            });
         });
-    });
+
+    feedbackStream
+        .on("close", () => {
+            console.log(calcAverageSentiment(sentimentScores));
+        })
 })();

--- a/main.js
+++ b/main.js
@@ -1,52 +1,69 @@
 const fs = require("fs");
+const path = require("path");
 const JSONStream = require("JSONStream");
 const { SentimentManager } = require("node-nlp");
 const { createWorker } = require("tesseract.js");
 
+
+// File Utils
+/**
+ * @param {string} file A string specifying a file
+ * @returns {bool} If a file is a JSON file
+ */
+const isJson = (file) => {
+    return path.extname(file).toLowerCase() === ".json";
+}
+
 // Main Driver
 (async () => {
-  const worker = await createWorker({
-    logger: (m) => console.log(m),
-  });
-
-  await worker.loadLanguage("eng");
-  await worker.initialize("eng");
-  const {
-    data: { text },
-  } = await worker.recognize(
-    "https://tesseract.projectnaptha.com/img/eng_bw.png"
-  );
-  console.log("imageText: ",text);
-  await worker.terminate();
-
-  
-  const feedbackCsvFile = process.argv[2];
-
-  const feedbackStream = fs.createReadStream(feedbackCsvFile, "utf-8");
-
-  feedbackStream.on("error", (error) => {
-    if (error.code === "ENOENT") {
-      console.log(
-        `File ${feedbackCsvFile} does not exist, please pass a valid file`
-      );
-    } else {
-      console.log(error);
-    }
-  });
-
-  const sentiment = new SentimentManager();
-
-  // Assumes the main JSON will only have a singular member which will
-  // be structured as an array of all feedback entries, wherein the
-  // user's written feedback will be in a member called "feedback"
-  feedbackStream.pipe(JSONStream.parse("*")).on("data", (chunk) => {
-    chunk.forEach((feedbackEntry) => {
-      sentiment.process("en", feedbackEntry.feedback).then((result) =>
-        console.log({
-          ...feedbackEntry,
-          sentiment_analysis: result,
-        })
-      );
+    // --------OCR--------
+    const worker = await createWorker({
+        logger: (m) => console.log(m),
     });
-  });
+
+    await worker.loadLanguage("eng");
+    await worker.initialize("eng");
+    const {
+        data: { text },
+    } = await worker.recognize(
+        "https://tesseract.projectnaptha.com/img/eng_bw.png"
+    );
+    console.log("imageText: ",text);
+    await worker.terminate();
+
+    // --------JSON Processing/Sentiment Analysis--------
+    const feedbackJsonFile = process.argv[2];
+
+    if (!isJson(feedbackJsonFile)) {
+        console.log(`${feedbackJsonFile} is not a .json file, program terminating`);
+        return;
+    }
+
+    const feedbackStream = fs.createReadStream(feedbackJsonFile, "utf-8");
+
+    feedbackStream.on("error", (error) => {
+        if (error.code === "ENOENT") {
+        console.log(
+            `File ${feedbackJsonFile} does not exist, please pass a valid file`
+        );
+        } else {
+        console.log(error);
+        }
+    });
+
+    const sentiment = new SentimentManager();
+
+    // Assumes the main JSON will only have a singular member which will
+    // be structured as an array of all feedback entries, wherein the
+    // user's written feedback will be in a member called "feedback"
+    feedbackStream.pipe(JSONStream.parse("*")).on("data", (chunk) => {
+        chunk.forEach((feedbackEntry) => {
+        sentiment.process("en", feedbackEntry.feedback).then((result) =>
+            console.log({
+            ...feedbackEntry,
+            sentiment_analysis: result,
+            })
+        );
+        });
+    });
 })();

--- a/main.js
+++ b/main.js
@@ -1,9 +1,9 @@
 const fs = require("fs");
 const path = require("path");
 const JSONStream = require("JSONStream");
-const { SentimentManager } = require("node-nlp");
 const { createWorker } = require("tesseract.js");
-const { default: BigNumber } = require("bignumber.js");
+
+const SentimentStatisticTracker = require("./utils/sentimentAnalysis.js");
 
 // File Utils
 /**
@@ -12,43 +12,6 @@ const { default: BigNumber } = require("bignumber.js");
  */
 const isJson = (file) => {
     return path.extname(file).toLowerCase() === ".json";
-}
-
-// Sentiment Analysis Utils
-/**
- * @param {BigNumber[]} sentimentScores An array of computed sentiment
- * scores from the JSON file of feedback
- * @returns {BigNumber} The average sentiment of the sentimentScores
- */
-const calcAverageSentiment = (sentimentScores) => {
-    const scoresAmt = sentimentScores.length;
-
-    // Avoids divide by 0 error
-    if (scoresAmt === 0) {
-        return 0;
-    }
-
-    let averageSentiment = new BigNumber(0);
-
-    sentimentScores.forEach(score => 
-        averageSentiment = score.plus(averageSentiment)
-    );
-
-    return averageSentiment.dividedBy(scoresAmt);
-}
-
-/**
- * Returns the vote of a sentiment score, whether or not a computed
- * sentiment was neutral, positive, or negative, based on senticon scoring,
- * the lexicon scoring system used by the SentimentManager to compute
- * sentiment per message
- * @param {BigNumber} sentimentScore A sentiment score
- * @returns {string} The vote of the score based on senticon scoring
- */
-const getSentimentVote = (sentimentScore) => {
-    if (sentimentScore.isEqualTo(0)) return "neutral";
-
-    return sentimentScore.isGreaterThan(0) ? "postive" : "negative";
 }
 
 // Main Driver
@@ -88,30 +51,19 @@ const getSentimentVote = (sentimentScore) => {
         }
     });
 
-    const sentimentScores = [];
-
-    const sentiment = new SentimentManager();
+    const sentiment = new SentimentStatisticTracker();
 
     // Assumes the main JSON will only have a singular member which will
     // be structured as an array of all feedback entries, wherein the
     // user's written feedback will be in a member called "feedback"
     feedbackStream.pipe(JSONStream.parse("*"))
         .on("data", chunk => {
-            chunk.forEach(feedbackEntry => {
-                sentiment.process("en", feedbackEntry.feedback).then(result => {
-                    sentimentScores.push(new BigNumber(result.score));
-
-                    console.log({
-                        ...feedbackEntry,
-                        sentiment_analysis: result
-                    });
-                });
-            });
+            chunk.forEach(feedbackEntry => sentiment.process(feedbackEntry));
         });
 
     feedbackStream
         .on("close", () => {
-            const averageSentiment = calcAverageSentiment(sentimentScores);
-            console.log(`Average sentiment of dataset is ${getSentimentVote(averageSentiment)} with a score of ${averageSentiment.toFixed()}`);
+            const averageSentiment = sentiment.calcAverageSentiment(sentiment.sentimentScores);
+            console.log(`Average sentiment of dataset is ${sentiment.getSentimentVote(averageSentiment)} with a score of ${averageSentiment.toFixed()}`);
         })
 })();

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -266,6 +266,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@microsoft/recognizers-text-number/node_modules/bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@microsoft/recognizers-text-sequence": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
@@ -540,9 +548,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
       "engines": {
         "node": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "bignumber.js": "^9.1.1",
         "JSONStream": "^1.3.5",
         "node-nlp": "^3.10.2"
       }
@@ -273,6 +274,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@microsoft/recognizers-text-number/node_modules/bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@microsoft/recognizers-text-sequence": {
@@ -549,9 +558,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bignumber.js": "^9.1.1",
     "JSONStream": "^1.3.5",
     "node-nlp": "^3.10.2"
   }

--- a/utils/sentimentAnalysis.js
+++ b/utils/sentimentAnalysis.js
@@ -1,0 +1,73 @@
+const { SentimentManager } = require("node-nlp");
+const { default: BigNumber } = require("bignumber.js");
+
+// Object to handle the sentiment analysis tracking
+class SentimentStatisticTracker {
+    constructor() {
+        this.sentimentManger = new SentimentManager();
+        this.sentimentScores = [];
+        this.language = "en";
+    }
+
+    /**
+     * Adds a sentiment score to the tracker's computed sentimentScores
+     * @param {Number} sentimentScore A computed sentiment score
+     */
+    addScore = sentimentScore => {
+        this.sentimentScores.push(new BigNumber(sentimentScore));
+    }
+
+    /**
+     * @param {Object} feedbackEntry An object consisting of a feedback_id,
+     * user_id, and a feedback entry, which contains a string from which we
+     * can process the sentiment of
+     */
+    process = feedbackEntry => {
+        this.sentimentManger.process(this.language, feedbackEntry.feedback)
+            .then(result => {
+                this.addScore(result.score);
+
+                console.log({
+                    ...feedbackEntry,
+                    "sentiment_analysis": result
+                });
+            });
+    }
+
+    /**
+     * @returns {BigNumber} The average sentiment of sentimentScores
+     */
+    calcAverageSentiment = () => {
+        const scoresAmt = this.sentimentScores.length;
+
+        // Avoids divide by 0 error
+        if (scoresAmt === 0) {
+            return 0;
+        }
+
+        let averageSentiment = new BigNumber(0);
+
+        this.sentimentScores.forEach(score => 
+            averageSentiment = score.plus(averageSentiment)
+        );
+
+        return averageSentiment.dividedBy(scoresAmt);
+    }
+
+    /**
+     * Returns the vote of a sentiment score, whether or not a computed
+     * sentiment was neutral, positive, or negative, based on senticon scoring,
+     * the lexicon scoring system used by the SentimentManager to compute
+     * sentiment per message
+     * @param {BigNumber} sentimentScore A sentiment score
+     * @returns {string} The vote of the score based on senticon scoring
+     */
+    getSentimentVote = (sentimentScore) => {
+        if (sentimentScore.isEqualTo(0)) return "neutral";
+
+        return sentimentScore.isGreaterThan(0) ? "postive" : "negative";
+    }
+}
+
+module.exports = SentimentStatisticTracker;
+


### PR DESCRIPTION
## Changes
1. Added bignumber.js module to the project for use of floating point calculations.
2. Added file extension check to main script to prevent user from passing non-JSON files as arguments to the script
3. Added feature to script to calculate the average sentiment of all feedback processed.
4. Refactored sentiment analysis to be in it's own utility JS file

## Purpose
To start adding floating point precision math logic to the project for when we have to start calculating more defined statistics for sentiment analysis on given data sets, and to start separating distinct features into their own files to clean the code and keep the main script from becoming too sprawling. Also to add more error/file type handling to the script.

## Approach
By using the bignumber.js module, we're able to ensure more precise calculations with the floating point scores calculated by the SentimentManager. By adding average sentiment calculation, we are able to show proof of concept of statistic generation using the scores generated by the SentimentManger. Through refactoring the sentiment analysis objects and functions to be in its own class, we can keep the code in the main script from becoming too crowded with different functionality. And by adding a file extension check to the script, we can ensure that only JSON files are the only valid file types to be passed to the script.

## Learning
Read the [bignumber.js documentation](https://www.npmjs.com/package/bignumber.js) to learn how to utilize it for floating point calculations.

Closes #006
