### PR TITLE
feat(average-sentiment-per-user): Made logic to track and calculate sentiment per user

### DIFF
--- a/data/test/diy-sentiment-analysis-test-data.json
+++ b/data/test/diy-sentiment-analysis-test-data.json
@@ -29,6 +29,21 @@
         "feedback_id": "5",
         "user_id": "8",
         "feedback": "It's not that I thought the service was bad, but I didn't think it was good either."
+      },
+      {
+        "feedback_id": "6",
+        "user_id": "8",
+        "feedback": "I changed my mind, the service here is outright horrible. Everyone treated me terribly."
+      },
+      {
+        "feedback_id": "7",
+        "user_id": "3",
+        "feedback": "Was reached out to by some people, they really went the extra mile to help me and I appreciate that"
+      },
+      {
+        "feedback_id": "8",
+        "user_id": "3",
+        "feedback": "Had a shockingly awful experience. Would not recommend."
       }
     ]
 }

--- a/data/test/diy-sentiment-analysis-test-data.json
+++ b/data/test/diy-sentiment-analysis-test-data.json
@@ -1,6 +1,6 @@
 {
     "data": [
-        {
+      {
         "feedback_id": "0",
         "user_id": "0",
         "feedback": "I found the service here above average at best."
@@ -27,12 +27,12 @@
       },
       {
         "feedback_id": "5",
-        "user_id": "8",
+        "user_id": "6",
         "feedback": "It's not that I thought the service was bad, but I didn't think it was good either."
       },
       {
         "feedback_id": "6",
-        "user_id": "8",
+        "user_id": "6",
         "feedback": "I changed my mind, the service here is outright horrible. Everyone treated me terribly."
       },
       {

--- a/main.js
+++ b/main.js
@@ -63,6 +63,14 @@ const isJson = (file) => {
 
     feedbackStream
         .on("close", () => {
+            console.log("----Average Sentiment Per User--------");
+            sentiment.userScores.forEach((value, key) => {
+                const userSentiment = sentiment.getAverageSentimentForUser(key);
+
+                console.log(`User of id [${key}] has an average ${sentiment.getSentimentVote(userSentiment)} sentiment of ${userSentiment.toFixed()}`);
+
+            });
+
             const averageSentiment = sentiment.calcOverallAverageSentiment(sentiment.sentimentScores);
             console.log(`Average sentiment of dataset is ${sentiment.getSentimentVote(averageSentiment)} with a score of ${averageSentiment.toFixed()}`);
         })

--- a/main.js
+++ b/main.js
@@ -63,7 +63,7 @@ const isJson = (file) => {
 
     feedbackStream
         .on("close", () => {
-            const averageSentiment = sentiment.calcAverageSentiment(sentiment.sentimentScores);
+            const averageSentiment = sentiment.calcOverallAverageSentiment(sentiment.sentimentScores);
             console.log(`Average sentiment of dataset is ${sentiment.getSentimentVote(averageSentiment)} with a score of ${averageSentiment.toFixed()}`);
         })
 })();

--- a/utils/sentimentAnalysis.js
+++ b/utils/sentimentAnalysis.js
@@ -6,7 +6,8 @@ class SentimentStatisticTracker {
     constructor() {
         this.sentimentManger = new SentimentManager();
         this.sentimentScores = [];
-        // Individual arrays for each user and their associated sentiment scores
+        // Maps individual arrays for each user and 
+        // their associated sentiment scores
         this.userScores = new Map(); 
         this.language = "en";
     }
@@ -27,7 +28,7 @@ class SentimentStatisticTracker {
             this.userScores.set(userId, []);
         }
 
-        this.userScores.get(userId).push(sentimentScore);
+        this.userScores.get(userId).push(newScore);
     }
 
     /**
@@ -57,6 +58,15 @@ class SentimentStatisticTracker {
     }
 
     /**
+     * 
+     * @param {string} userId 
+     * @returns {BigNumber}
+     */
+    getAverageSentimentForUser(userId) {
+        return this.calcAverageSentiment(this.userScores.get(userId));
+    }
+
+    /**
      * Given an array of sentiment scores, returns that array's average
      * @param {BigNumber[]} sentiments An array of sentiment scores
      * @returns {BigNumber} The average sentiment of the sentiments
@@ -71,7 +81,8 @@ class SentimentStatisticTracker {
 
         let averageSentiment = new BigNumber(0);
 
-        this.sentimentScores.forEach(score => 
+
+        sentiments.forEach(score => 
             averageSentiment = averageSentiment.plus(score)
         );
 

--- a/utils/sentimentAnalysis.js
+++ b/utils/sentimentAnalysis.js
@@ -43,6 +43,11 @@ class SentimentStatisticTracker {
         return this.calcAverageSentiment(this.sentimentScores);
     }
 
+    /**
+     * Given an array of sentiment scores, returns that array's average
+     * @param {BigNumber[]} sentiments An array of sentiment scores
+     * @returns {BigNumber} The average sentiment of the sentiments
+     */
     calcAverageSentiment(sentiments) {
         const scoresAmt = sentiments.length;
 

--- a/utils/sentimentAnalysis.js
+++ b/utils/sentimentAnalysis.js
@@ -6,15 +6,28 @@ class SentimentStatisticTracker {
     constructor() {
         this.sentimentManger = new SentimentManager();
         this.sentimentScores = [];
+        // Individual arrays for each user and their associated sentiment scores
+        this.userScores = new Map(); 
         this.language = "en";
     }
 
     /**
-     * Adds a sentiment score to the tracker's computed sentimentScores
+     * Adds a sentiment score to the tracker's computed sentimentScores,
+     * and associates the score with a user
      * @param {Number} sentimentScore A computed sentiment score
+     * @param {string} userId A string indicating the id of the user whose
+     * feedback was scord
      */
-    addScore(sentimentScore) {
-        this.sentimentScores.push(new BigNumber(sentimentScore));
+    addScore(sentimentScore, userId) {
+        const newScore = new BigNumber(sentimentScore);
+
+        this.sentimentScores.push(newScore);
+
+        if (!this.userScores.has(userId)) {
+            this.userScores.set(userId, []);
+        }
+
+        this.userScores.get(userId).push(sentimentScore);
     }
 
     /**
@@ -27,7 +40,7 @@ class SentimentStatisticTracker {
     process(feedbackEntry) {
         this.sentimentManger.process(this.language, feedbackEntry.feedback)
             .then(result => {
-                this.addScore(result.score);
+                this.addScore(result.score, feedbackEntry["user_id"]);
 
                 console.log({
                     ...feedbackEntry,

--- a/utils/sentimentAnalysis.js
+++ b/utils/sentimentAnalysis.js
@@ -13,16 +13,18 @@ class SentimentStatisticTracker {
      * Adds a sentiment score to the tracker's computed sentimentScores
      * @param {Number} sentimentScore A computed sentiment score
      */
-    addScore = sentimentScore => {
+    addScore(sentimentScore) {
         this.sentimentScores.push(new BigNumber(sentimentScore));
     }
 
     /**
+     * Processes a feedback entry by calculating its feedback and adding it 
+     * to the total sentimentScores calculated
      * @param {Object} feedbackEntry An object consisting of a feedback_id,
      * user_id, and a feedback entry, which contains a string from which we
      * can process the sentiment of
      */
-    process = feedbackEntry => {
+    process(feedbackEntry) {
         this.sentimentManger.process(this.language, feedbackEntry.feedback)
             .then(result => {
                 this.addScore(result.score);
@@ -37,8 +39,12 @@ class SentimentStatisticTracker {
     /**
      * @returns {BigNumber} The average sentiment of sentimentScores
      */
-    calcAverageSentiment = () => {
-        const scoresAmt = this.sentimentScores.length;
+    calcOverallAverageSentiment() {
+        return this.calcAverageSentiment(this.sentimentScores);
+    }
+
+    calcAverageSentiment(sentiments) {
+        const scoresAmt = sentiments.length;
 
         // Avoids divide by 0 error
         if (scoresAmt === 0) {
@@ -48,7 +54,7 @@ class SentimentStatisticTracker {
         let averageSentiment = new BigNumber(0);
 
         this.sentimentScores.forEach(score => 
-            averageSentiment = score.plus(averageSentiment)
+            averageSentiment = averageSentiment.plus(score)
         );
 
         return averageSentiment.dividedBy(scoresAmt);
@@ -62,7 +68,7 @@ class SentimentStatisticTracker {
      * @param {BigNumber} sentimentScore A sentiment score
      * @returns {string} The vote of the score based on senticon scoring
      */
-    getSentimentVote = (sentimentScore) => {
+    getSentimentVote(sentimentScore) {
         if (sentimentScore.isEqualTo(0)) return "neutral";
 
         return sentimentScore.isGreaterThan(0) ? "postive" : "negative";


### PR DESCRIPTION
## Changes
1. Added data to the test JSON file
2. Added data structures and logic to track each user's computed feedback sentiment scores and average sentiment score

## Purpose
To add logic to the script that helps track feedback sentiment per user.

## Approach
By adding a Map object to the SentimentStatisticTracker, we are able to store each user's feedback's sentiment score and track the average sentiment of each of their feedback entries.

## Learning
Read a [StackOverflow post](https://stackoverflow.com/questions/12636613/how-to-calculate-moving-average-without-keeping-the-count-and-data-total) and [Wikipedia article](https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm) on Welford's Algorithm in order to implement each user's average sentiment score calculation as a running average to avoid extraneous operations after the script processes the JSON file.

Closes #009
