### PR TITLE
feat(sentiment-analysis-spanish-support): Applied language guessing logic to sentiment analysis

### DIFF
--- a/main.js
+++ b/main.js
@@ -69,10 +69,11 @@ async function processMessage(sentiment, conversationId, message) {
     const imageContent = imageData && await performOCR(imageData);
 
     if (!imageContent) {
+        sentiment.setLanguage(languageGuess.alpha2);
         sentiment.process(conversationId, message);
 
         // console.log('messages: ', message.body);
-        // console.log('Language Guess: ', languageGuess.language)
+        // console.log('Language Guess: ', languageGuess);
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -65,15 +65,14 @@ async function performOCR(base64Image) {
  */
 async function processMessage(sentiment, conversationId, message) {
     const imageData = filterBase64Data(message.body);
+    const languageGuess = guessLanguage(message.body);
     const imageContent = imageData && await performOCR(imageData);
 
     if (!imageContent) {
         sentiment.process(conversationId, message);
 
-        // console.log('messages: ', message.body)
-
-        const languageGuess = guessLanguage(message.body)
-        console.log('Language Guess: ', languageGuess.language)
+        // console.log('messages: ', message.body);
+        // console.log('Language Guess: ', languageGuess.language)
     }
 }
 
@@ -112,8 +111,8 @@ async function processMessage(sentiment, conversationId, message) {
                 conversationIds.map(async conversationId => {
                     const messages = chunk[conversationId];
 
-                    await Promise.all(messages.map(message => 
-                        processMessage(sentiment, conversationId, message)
+                    await Promise.all(messages.map(async message => 
+                        await processMessage(sentiment, conversationId, message)
                     ));
                 })
             );

--- a/utils/languageGuesserModel.js
+++ b/utils/languageGuesserModel.js
@@ -10,6 +10,6 @@ const guessLanguage = (text) => {
     return guess   
 }
 
-console.log(guessLanguage(text))
+// console.log(guessLanguage(text))
 
 module.exports = guessLanguage

--- a/utils/sentimentAnalysis.js
+++ b/utils/sentimentAnalysis.js
@@ -14,6 +14,7 @@ class SentimentStatisticTracker {
         // for that conversation
         this.conversationScores = new Map();
         this.language = "en";
+        this.supportedLanguges = ["en", "es"]
     }
     
     // --------MAIN METHODS--------
@@ -63,6 +64,18 @@ class SentimentStatisticTracker {
 
         const averageSentiment = this.calcOverallAverageSentiment(this.sentimentScores);
         console.log(`Average sentiment of dataset is ${this.getSentimentVote(averageSentiment)} with a score of ${averageSentiment.toFixed()}`);
+    }
+
+    // --------SETTERS--------
+    /**
+     * Sets the language for sentiment analysis to a given language 
+     * if it supported
+     * @param {string} language A supported alpha2 language string
+     */
+    setLanguage(language) {
+        if (this.supportedLanguges.includes(language)) {
+            this.language = language;
+        }
     }
 
     // --------SENTIMENT STAT TRACKING HELPERS--------


### PR DESCRIPTION
## Changes
1. Added language setter to SentimentStatisticTracker
2. Called sentiment language setter using the language guesser in the main script

## Purpose
To add support for Spanish in sentiment analysis

## Approach
By applying the language guessing logic to the SentimentStatisticTracker, sentiment analysis can be performed on Spanish content as necessary

Closes #025
