### PR TITLE
chore: Revert version of node-nlp to 3.10.2

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,72 +4,266 @@
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
-    "node_modules/@microsoft/recognizers-text": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.3.1.tgz",
-      "integrity": "sha512-HikLoRUgSzM4OKP3JVBzUUp3Q7L4wgI17p/3rERF01HVmopcujY3i6wgx8PenCwbenyTNxjr1AwSDSVuFlYedQ==",
+    "node_modules/@bluelovers/fast-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bluelovers/fast-glob/-/fast-glob-3.0.4.tgz",
+      "integrity": "sha512-djAOOjDWXolYArm5NXxOIX7Q7OGhAaRtMs5F968OxelWkMUU6PyU6tS66CFykVON4U5y8jXcsnVAFCaeuf1nEA==",
+      "dependencies": {
+        "bluebird": "^3",
+        "fast-glob": "^3"
+      }
+    },
+    "node_modules/@bluelovers/fill-range": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@bluelovers/fill-range/-/fill-range-7.0.2.tgz",
+      "integrity": "sha512-KBuuuw6L/FoRUEhgpwM3z5wJ2Zo4ociL5hb7D/B4LDhe5U0Z3CL53i1+c1fcUXx1wExLyA77wtvzK5j+qEigyw==",
+      "dependencies": {
+        "@bluelovers/to-regex-range2": "^5.0.1"
+      },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bluelovers/string-natural-compare": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@bluelovers/string-natural-compare/-/string-natural-compare-2.0.11.tgz",
+      "integrity": "sha512-k2KanWgqg6scH37zI7xd/5jFdFWg+V6Z9P1sl3RxrA855AFLbcFeAJMGMN8Dop547MUh5Tq3KKVttvE8DY5yUA==",
+      "dependencies": {
+        "string-natural-compare2": "^3.0.1"
+      }
+    },
+    "node_modules/@bluelovers/to-regex-range2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@bluelovers/to-regex-range2/-/to-regex-range2-5.0.1.tgz",
+      "integrity": "sha512-0fVn7EqIBAZjlnyzz87E5JUs0H+4KwW/i2RVzWRbcjb+xBxD0TIvRGUYGrfvb5eiQf0cuJn4F/zkTmd0cgrA0g==",
+      "dependencies": {
+        "@lazy-assert/check-basic": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@lazy-array/util-unique": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lazy-array/util-unique/-/util-unique-1.0.4.tgz",
+      "integrity": "sha512-zSffxqZZ8VhO068JG+HlYaUJC5ciCdyJnuUYysntTObrwLsA5bS+A09vhSVZ/On8ft+bOMYoAhAZOTw9Y0q70g=="
+    },
+    "node_modules/@lazy-assert/check-basic": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@lazy-assert/check-basic/-/check-basic-1.0.12.tgz",
+      "integrity": "sha512-Zttg9K7CBNcNlGDM+AQ9rqschYJ0c8tvJ/35iBuiqefZ9RuaW9C1Ww0AGgp9MVLL/h1/uBbY6CDuz+VRzCDDAg=="
+    },
+    "node_modules/@lazy-cjk/japanese": {
+      "version": "1.2.33",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/japanese/-/japanese-1.2.33.tgz",
+      "integrity": "sha512-n5M/eL6QQd1i/JH3cZ4L2Z3WkeNOXfIUlLt21Zvi4o1YGpth2Nf4OLVuPp/SwYYOpFfaN6JT9YkJ49ZOuIAKgA==",
+      "dependencies": {
+        "big.js": "^6.2.1",
+        "lodash": "^4.17.21",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-alias": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-alias/-/jp-table-alias-1.0.41.tgz",
+      "integrity": "sha512-Sv0vw0JhJqtYEhF5HgQVQ+eSRSejFCUdcHEafstaMCQ3juVaVSfe6b4LOj339+rucUEduBznnMy6LqXMp7MJ7A==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-comparison": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-comparison/-/jp-table-comparison-1.0.29.tgz",
+      "integrity": "sha512-yy+KrAk9ORhjJHB3VOWiQ/Wrx+CGP2PwCjixqRuw7xU1v2p8QRSiDAcPvh1FX+ObD/fenRq09NMEAw3X8pJlJg==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-convert": {
+      "version": "1.0.46",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-convert/-/jp-table-convert-1.0.46.tgz",
+      "integrity": "sha512-VhOGMBm1WGh0rUNCwJmVKPIuXVV5KcOqvynrwZUm7HJ6zsccNDPR7PsxFX0L5uS0xC7JdKgjlr2WrmgzY5lXGA==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-comparison": "^1.0.29",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-voice": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-voice/-/jp-table-voice-1.0.37.tgz",
+      "integrity": "sha512-v1fnb1gBsjJ6fm2dQdFflH9gfQimg8tD6MoIpqlgaAiOTMtLina+MnmFoIw39WZp1ARiHAXqvO4Z6DgZRmp+2g==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/novel-filename": {
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/novel-filename/-/novel-filename-1.0.50.tgz",
+      "integrity": "sha512-msjq8cXWGz8VZVGW5TR5+1MfH6RN73NZzPmv6yfzAZ04TJsQqAy0qvkRfl9oGYfxdIoly7tzq0TSf81VKh40Xg==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/regexp-range-table": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/regexp-range-table/-/regexp-range-table-1.0.4.tgz",
+      "integrity": "sha512-Awt1XSFQQjxEgHORhJPkMfbPpxs2cvQXDFXqpK0fXYy3OyhJDUzZMS8wEWhf208kbbMefEWmVtbC2T2E+GagvQ=="
+    },
+    "node_modules/@lazy-cjk/static-build-zh-convert": {
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/static-build-zh-convert/-/static-build-zh-convert-1.0.51.tgz",
+      "integrity": "sha512-COEoNSL/wX08D2Epf8sItnSMFA9t2/imYJM5N+sglLY0sWaWM9T/bNcBAQTpLggslmylUX/IOZ14XxbJjkmzPg==",
+      "dependencies": {
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/util": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/util/-/util-1.0.18.tgz",
+      "integrity": "sha512-5Hxm60wBaulhBQmOeAOdvNky/BRTckeo/nZFS/SwOr9mPdczn6NHn4Nqbk4XMqZCvBbOBFnren85MKo5y/UsbQ==",
+      "dependencies": {
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-convert": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-convert/-/zh-convert-1.0.48.tgz",
+      "integrity": "sha512-yRf5K24JAtpysXYloI4FhLmzcdbDleR5T25/H7QHoz+Qx+lj86/Bf1Ta9mLnElv9liFgE0RWGEeppKs5rZqQzA==",
+      "dependencies": {
+        "@lazy-cjk/static-build-zh-convert": "^1.0.51",
+        "array-hyper-unique": "^2.1.4",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-convert-table": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-convert-table/-/zh-convert-table-1.0.23.tgz",
+      "integrity": "sha512-73kuMrTkwSEWeFI0ZI57JdIDBieh+yXk6s1A9NMBf1tgGnV2DR8c+BMVTalVDbhx8Skyh69iXawdP7/aeElfyw==",
+      "dependencies": {
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-slugify": {
+      "version": "1.0.86",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-slugify/-/zh-slugify-1.0.86.tgz",
+      "integrity": "sha512-P/xjZTsQYfCIv9qH6hlLvkuYxI3tpDVT9gPQ52+NkJrQyORZiJub+z4mmqBHf/ZXgo/+ZVeKzo8UCp6YT0LCUQ==",
+      "dependencies": {
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-table-alias": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-alias/-/zh-table-alias-1.0.62.tgz",
+      "integrity": "sha512-ppNQ4VGP+zaBGUGvXPeLANc8zy6Yi9r3pzVySB+ypy+n3C43QOpJJoWtIvEuKfmFGju4ZKO6CucCwEnf9U3mwQ==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-alias": "^1.0.41",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "array-hyper-unique": "^2.1.4",
+        "deepmerge-plus": "^2.1.3",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-table-greedy": {
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-greedy/-/zh-table-greedy-1.0.90.tgz",
+      "integrity": "sha512-ktk6dH9yuGPJEmEZtliYCNALbKO6jfmXjSFabnF1hgNW/uk2rg5r5nydyFXa4rECclSbk88xT0sXe2cBTOf30A==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-table-list": {
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-list/-/zh-table-list-1.0.84.tgz",
+      "integrity": "sha512-xzzQf2rDSmovYT98gHTN2LXGITsy1NNIbu6Klp2zC2Tk0SjeUcRhMxJjVWQUtXBbBQ3UlSZKrTvutpRFjVja0g==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "@lazy-cjk/zh-table-alias": "^1.0.62",
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@microsoft/recognizers-text": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
+      "integrity": "sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-choice": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.3.1.tgz",
-      "integrity": "sha512-HubunMJVq/OetmdvcAmBh5skMlg+yiScm3V2wNyNZIVvLgli4+8nzbg/W/fI9dpaf6wv9ZQ7d2IYvn8swJBo3A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.4.tgz",
+      "integrity": "sha512-4CddwFe4RVhZeJgW65ocBrEdeukBMghK8pgI0K0Qy2eA5ysPZQpeZ7BGSDz5QMQei5LPY+QaAQ3CHU+ORHoO7A==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "grapheme-splitter": "^1.0.2"
       },
       "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-data-types-timex-expression": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.3.1.tgz",
-      "integrity": "sha512-jarJIFIJZBqeofy3hh0vdQo1yOmTM+jCjj6/zmo9JunsQ6LO750eZHCg9eLptQhsvq321XCt5xdRNLCwU8YeNA==",
-      "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-date-time": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.3.2.tgz",
-      "integrity": "sha512-fUEGOTccS55ZY0erzjS1bunJYA9lGXjcZoru5oPOlnxbJS4Lk0ylgdH2Ub2EjAyqr8DIJhdLNOEesCdAXMvlNg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.4.tgz",
+      "integrity": "sha512-leMnjN+KYNwNvRD5T4G0ORUzkjlek/BBZDvQIjAujtyrd/pkViUnuouWIPkFT/dbSOxXML8et54CSk2KfHiWIA==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
-        "@microsoft/recognizers-text-number": "~1.3.1",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.1",
-        "lodash": "^4.17.21"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "lodash.isequal": "^4.5.0",
+        "lodash.tonumber": "^4.0.3"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-number": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.3.1.tgz",
-      "integrity": "sha512-JBxhSdihdQLQilCtqISEBw5kM+CNGTXzy5j5hNoZECNUEvBUPkAGNEJAeQPMP5abrYks29aSklnSvSyLObXaNQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.4.tgz",
+      "integrity": "sha512-6EmlR+HR+eJBIX7sQby1vs6LJB64wxLowHaGpIU9OCXFvZ5Nb0QT8qh10rC40v3Mtrz4DpScXfSXr9tWkIO5MQ==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "bignumber.js": "^7.2.1",
-        "lodash": "^4.17.21"
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.sortby": "^4.7.0",
+        "lodash.trimend": "^4.5.1"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-number-with-unit": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.3.1.tgz",
-      "integrity": "sha512-gzCpPP4zQ5Vb+RHaWjzP2t1c+mj6GYOsFoI2NyJkm8OZ52XI+x9SJCgrrD2ujzjOd5/CQVC46rE22rfGwXLDkA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz",
+      "integrity": "sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
-        "@microsoft/recognizers-text-number": "~1.3.1",
-        "lodash": "^4.17.21"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.last": "^3.0.0",
+        "lodash.max": "^4.0.1"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-number/node_modules/bignumber.js": {
@@ -81,581 +275,256 @@
       }
     },
     "node_modules/@microsoft/recognizers-text-sequence": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.3.1.tgz",
-      "integrity": "sha512-J7Kg35hpm0NcFHmu69Bb4q7DPDiSpCd8ApUZqNm59itIjrQJHpSdl9HF6JxuQQz0Ftc/li5ZLqSuupJAmA/sgg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
+      "integrity": "sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "grapheme-splitter": "^1.0.2"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-suite": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.3.0.tgz",
-      "integrity": "sha512-uqG4vzy5N2CmBaeINny0bLdnGp0jDbT1moNoLC+Yim3G8kHOU9lpDfwA6VN6HTYaDM5854SNMEzLjJdS1TPFTw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.4.tgz",
+      "integrity": "sha512-hNIaR4M2G0nNeI9WZxt9C0KYh/1vhjeKzX5Ds8XDdT0pxF7zwCSo19WNcPjrVK6aCOeZTw/ULofsAjdu9gSkcA==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "@microsoft/recognizers-text-choice": "~1.3.0",
-        "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
-        "@microsoft/recognizers-text-date-time": "~1.3.0",
-        "@microsoft/recognizers-text-number": "~1.3.0",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-        "@microsoft/recognizers-text-sequence": "~1.3.0"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-choice": "~1.1.4",
+        "@microsoft/recognizers-text-date-time": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "@microsoft/recognizers-text-sequence": "~1.1.4"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/@nlpjs/builtin-duckling": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-duckling/-/builtin-duckling-4.26.1.tgz",
-      "integrity": "sha512-3qkH955X2g5MXV1EqT3fTAT/lLEdiqqe5IgBDyr+MQB7FOV9R3YhqGIn3DFOl+TSm/tP5n/BAEptkTNn/TOpmQ==",
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/builtin-microsoft": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-microsoft/-/builtin-microsoft-4.26.1.tgz",
-      "integrity": "sha512-AODgzTcfYUf5Ozm00aQnHImDum7Idtl0F9dSPoaXpfj7rZqP8hPZ7iWwdGTAvISH/da2YhjPOU65QSYk2YpjFA==",
-      "dependencies": {
-        "@microsoft/recognizers-text-suite": "1.3.0",
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/core": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.26.1.tgz",
-      "integrity": "sha512-M/PeFddsi3y7Z1piFJxsLGm5/xdMhcrpOsml7s6CTEgYo8iduaT30HDd61tZxDyvvJseU6uFqlXSn7XKkAcC1g=="
-    },
-    "node_modules/@nlpjs/core-loader": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core-loader/-/core-loader-4.26.1.tgz",
-      "integrity": "sha512-IiRtn65bdiUSQHy2kusco2fmhk39u2Mc2c5Fsm9+9EVG6BtJCmVEFU/btAzGDAmxEA/E4qKecaAT4LvcW6TPbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/request": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/emoji": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/emoji/-/emoji-4.26.1.tgz",
-      "integrity": "sha512-Q0PoXwIvaB1bnRXK4U/YD7mrqaz29Yfed3s2au0iXl1bffUgoG+hs4GORCvyy7DFCCLlc9d5yDM3oLIX/ggZ+Q==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/evaluator": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/evaluator/-/evaluator-4.26.1.tgz",
-      "integrity": "sha512-WeUrC8qq7+V8Jhkkjc2yiXdzy9V0wbETv8/qasQmL0QmEuwBDJF+fvfl4z2vWpBb0vW07A8aNrFElKELzbpkdg==",
-      "dependencies": {
-        "escodegen": "^2.0.0",
-        "esprima": "^4.0.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-all": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.26.1.tgz",
-      "integrity": "sha512-UzRm1JRRAyQqilEOxQ2ySMOitKbhPk5iKYbjD8FREDcPjreUvDxVuQsYUOvYucmEyFcZU2U/TdJx+fX9/bcaKQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-ar": "^4.26.1",
-        "@nlpjs/lang-bn": "^4.26.1",
-        "@nlpjs/lang-ca": "^4.26.1",
-        "@nlpjs/lang-cs": "^4.26.1",
-        "@nlpjs/lang-da": "^4.26.1",
-        "@nlpjs/lang-de": "^4.26.1",
-        "@nlpjs/lang-el": "^4.26.1",
-        "@nlpjs/lang-en": "^4.26.1",
-        "@nlpjs/lang-es": "^4.26.1",
-        "@nlpjs/lang-eu": "^4.26.1",
-        "@nlpjs/lang-fa": "^4.26.1",
-        "@nlpjs/lang-fi": "^4.26.1",
-        "@nlpjs/lang-fr": "^4.26.1",
-        "@nlpjs/lang-ga": "^4.26.1",
-        "@nlpjs/lang-gl": "^4.26.1",
-        "@nlpjs/lang-hi": "^4.26.1",
-        "@nlpjs/lang-hu": "^4.26.1",
-        "@nlpjs/lang-hy": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1",
-        "@nlpjs/lang-it": "^4.26.1",
-        "@nlpjs/lang-ja": "^4.26.1",
-        "@nlpjs/lang-ko": "^4.26.1",
-        "@nlpjs/lang-lt": "^4.26.1",
-        "@nlpjs/lang-ms": "^4.26.1",
-        "@nlpjs/lang-ne": "^4.26.1",
-        "@nlpjs/lang-nl": "^4.26.1",
-        "@nlpjs/lang-no": "^4.26.1",
-        "@nlpjs/lang-pl": "^4.26.1",
-        "@nlpjs/lang-pt": "^4.26.1",
-        "@nlpjs/lang-ro": "^4.26.1",
-        "@nlpjs/lang-ru": "^4.26.1",
-        "@nlpjs/lang-sl": "^4.26.1",
-        "@nlpjs/lang-sr": "^4.26.1",
-        "@nlpjs/lang-sv": "^4.26.1",
-        "@nlpjs/lang-ta": "^4.26.1",
-        "@nlpjs/lang-th": "^4.26.1",
-        "@nlpjs/lang-tl": "^4.26.1",
-        "@nlpjs/lang-tr": "^4.26.1",
-        "@nlpjs/lang-uk": "^4.26.1",
-        "@nlpjs/lang-zh": "^4.26.1",
-        "@nlpjs/language": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/lang-ar": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ar/-/lang-ar-4.26.1.tgz",
-      "integrity": "sha512-MUlVtabt9ltG7WyzCQpFJymLJlnEqp3mxhgN9JHyFH7oZMK3REvMovFfvEUAbfiYrJEv/BN5KKLL7yrvUeaHtg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-bn": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.26.1.tgz",
-      "integrity": "sha512-sim1iZKBDdehi/yBUKrLW51QvS9uB+sXW7lj+THVqBy5UsnEQvt4gzE0NsC873uJMh66vt2AlHkhzgPH0qH/nQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ca": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ca/-/lang-ca-4.26.1.tgz",
-      "integrity": "sha512-fD4R5tcAB0uYtNxSEF20b1KmF6nUQSbiJqrIUJI5yis4ObjCYRQnSh4bjVDKUKxyONjbD6L8EaK5GrY1/jkwFQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-cs": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.26.1.tgz",
-      "integrity": "sha512-CqI6VB8toaJ/MlP1D4K9BctA6GpZJhMKyEy+OX9xavDe4r4ao/SxlSaIYK3izK0k+J38lJWC5lXYGazfCdTGjA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-da": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-da/-/lang-da-4.26.1.tgz",
-      "integrity": "sha512-krI/ojeDSi329ENM/hLIsbUh1x4XRTKAbtPcbFxAY6XVhcSVoWPO7L77jFTL1NQeE1oGRFzGHaeC9hZJ8phVbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-de": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.26.1.tgz",
-      "integrity": "sha512-HfZQwsE5FICq9taVZDiyktmdAePVF5948NM80et0d9mx43RWDFhHKQYgtJPwfQXtdCoQtOM5TOJ2FanGwzPeaA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-el": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-el/-/lang-el-4.26.1.tgz",
-      "integrity": "sha512-pcOvuSwPCXxI+2xNZZzM4V5pTRDntYoJi0SP/ic2nV4IPQ0nU2j16dYfg1HlvET/E6iN1VTqghrCaf10SMkDGA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-en": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en/-/lang-en-4.26.1.tgz",
-      "integrity": "sha512-GVoJpOjyk5TtBAqo/fxsiuuH7jXycyakGT0gw5f01u9lOmUnpJegvXyGff/Nb0j14pXcGHXOhmpWrcTrG2B0LQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-en-min": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-en-min": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.26.1.tgz",
-      "integrity": "sha512-1sJZ7dy7ysqzbsB8IklguvB88J8EPIv4XGVkZCcwecKtOw+fp5LAsZ3TJVmEf18iK1gD4cEGr7qZg5fpPxTpWQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-es": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.26.1.tgz",
-      "integrity": "sha512-fIPQt+WPcNdyxZOCMkOPlMb4Y1iE585QxjB9IAdFz8ZtVg7mc4dlv5f46ud7ppdMh84iLOuOdo6pzu2Cqm14lw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-eu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-eu/-/lang-eu-4.26.1.tgz",
-      "integrity": "sha512-Ha8GHTbgQYd7dwHM8aWHDyxmbUNUcyu/5xlBKqqBOPxysDyZ6Ad0tvj0FmJBy6mYhqmFTPBnEAo69cfuFSqWIQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fa": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.26.1.tgz",
-      "integrity": "sha512-qJCmNXgJZnfNXUnKnxvEGEzSFBdQT4XU7/rMxuFmSJqmQY7fH/Vsmi5CKF94VRBPOIV4ULlEJuLpUWHXRmOnVQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fi/-/lang-fi-4.26.1.tgz",
-      "integrity": "sha512-W/rUcrzSh3KE07q2vOsssTpU1sbX32gbBzKPZfRJ2ZUF4afO+eHxmAywikXubP4kiU3JxVNLvXXEjuGD3SBUbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.26.1.tgz",
-      "integrity": "sha512-LTA852atCJnHtKDmtjx/ui5AnvEIkrPx+MJQ2mB3gn8ko6i2UITnJgPmJE9Kej5bLasVZOAJvU/SrfXEmnPGOw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ga": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ga/-/lang-ga-4.26.1.tgz",
-      "integrity": "sha512-JsP1CZ8r3Jd6o/Az7cN3exz0HDP3FNYLzh4Vi6ksEkdKF0yCjJ9G5dXZYqS9qFIN5ffemWn29G4WRELY6QH/cQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-gl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.26.1.tgz",
-      "integrity": "sha512-y1NNu6NVy/6o5UNfihgg0WkSlVr4IvKA5W193CpRLZWS4FccQDmnFFhyYWRkshyDbgEsfsZ0Rs3BoE82+T2Ubg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hi/-/lang-hi-4.26.1.tgz",
-      "integrity": "sha512-Fw9rXqF5l8q9etJG5uOlEFpnMVjQEWMaCIgQfEcA1yTvieSV8mpoSvQkEZl+DFhww+azareoJ7ZCkx0gJ9UDuQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.26.1.tgz",
-      "integrity": "sha512-7dPUn5/ZpLZmsdRwO+dtORuMIiIpnsWbgSLIKdOLh8irhgUR+M2bYTfkdnKcrEcHzHPP8Svn7pU0xk7OKSUA1w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hy": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hy/-/lang-hy-4.26.1.tgz",
-      "integrity": "sha512-T2brpLGDJryAwWmjtnmY8Ot6ZUkCz+/nRR9/QM1PybvZIqOVLjJqA49bqjJfT5DMN89HbwC7I/15NTT0y09i1Q==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-id": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.26.1.tgz",
-      "integrity": "sha512-rVuIkYFKdltFhMT/a2ZxD9ovoZSVZF7OPuqYjTXW9xKd3Ff32yUrzcf/pHXlqmZOSltqOH3E5jZRRDkHvgUOjQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-it": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-it/-/lang-it-4.26.1.tgz",
-      "integrity": "sha512-BZA3QnfQGW91gYaybRmHnCAPBvQggtmHZJrAmuBZUKUS12HoQm8uybjw2fZO+vahEeUQceKNDISRcT1eLLijog==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ja": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.26.1.tgz",
-      "integrity": "sha512-QgkuJOkHguRFyfnckH2It5/Kg8zecnOMJsHxYeuDC4tBF7jL/5xqWis+679lYLsXtAkrG8+fjVcBbjyopP0KHg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "kuromoji": "^0.1.2"
-      }
-    },
-    "node_modules/@nlpjs/lang-ko": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ko/-/lang-ko-4.26.1.tgz",
-      "integrity": "sha512-Q0N8bLJJ829ILWCKH1UQWPSNyuLaEURAXCawkDju4pt33DBLcpqz9IzO9dnqiFc+fjSgVzZ7WMaLT18hXZQ9vg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-lt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.26.1.tgz",
-      "integrity": "sha512-SeYZxRhdCy+ClQNnF/u0MAtcDui/ocdk4NtgNOCuwNTNuzhN3t3rfGeArfBGmZeg1SIeBLUDE9dsTxYCv5AOEg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ms": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ms/-/lang-ms-4.26.1.tgz",
-      "integrity": "sha512-KxWBS+tFY2U8z9UrjQIqMM40npGDOskP5DcWhaEE3zuhzf3RTDYjy8sdz34jVd0fBdbPihX133h3bFibg2Cm7w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ne": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.26.1.tgz",
-      "integrity": "sha512-K3E2l+0LTESv+dO+ZTIdvNa+zwMJvvnMiFYYkKvJst6lhc8JgvGOsPxGsjJn6PDhI3wyfQu+dg3b+bnVPu4FDA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-nl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-nl/-/lang-nl-4.26.1.tgz",
-      "integrity": "sha512-I/mP1RRbUN4BQ+8NXAl2FKaLHbb7f6S8JVjxHQ0sKHT4BgQ3+r0yO+DVcEsHg+vWRiY1Fyzh0gq0PhLVnF6HnA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-no": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.26.1.tgz",
-      "integrity": "sha512-a0CLL2c/OCzbg7J7ugyrsAksI96XhkQ3IeBbbx60o5o/9wsFNik6cPWrkpoE5xNtw7gLlAJWabwDiZXkl8Zrcw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-pl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pl/-/lang-pl-4.26.1.tgz",
-      "integrity": "sha512-nrDXlq+TzQLE5IpXPIlFMzd8OpquvApWsouh6fmLsD9HZLZI4O3w1M4sXXLzE+9Ggu9Cy1m1QJ0/i7XCcv115g==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-pt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.26.1.tgz",
-      "integrity": "sha512-p6yZHaJ0e+n0avMHpdDw5PMk4HkKXjPbOMbrlg0dF+VRqChjxfH478Q423rDyzu/4MzDsIYB+p6KzL9AARKXpg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ro": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ro/-/lang-ro-4.26.1.tgz",
-      "integrity": "sha512-baUdTA0DWpDR0Tn6fxo+RDN/6gbuINLCARtHwap2UR/HKQWP2XoH/DIvcjZpwUTalr5MQjso31epcdeRRapczA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ru": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.26.1.tgz",
-      "integrity": "sha512-NaZ2DAOGxWG2Us9IyIDs3m6vhGpUaUJRVgzzHHyX3LO3xEYjZmtnA0jEpBaTOe2PuNHThv0WCZUNn9BSurV3PA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sl/-/lang-sl-4.26.1.tgz",
-      "integrity": "sha512-QBJwcJt+oKUpAnHKNJkLkx9Xm1n4dUPC5GPYfAXTnJZf0hNWJSY21GicdWi7Vu/qFJ3ghIqtSP8D7KIPLnibNw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.26.1.tgz",
-      "integrity": "sha512-drH3+UqTW637uLWsnLrcp8jEKUGxV61ZgCBjNkVQNEv1/jbpSg6IqgynSY2JyhtnlV0f870KS0HvSbyo5AD4Ng==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sv": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sv/-/lang-sv-4.26.1.tgz",
-      "integrity": "sha512-2axkrYFC02tAlxCWeiEKISbe4dSteciP1CIggO/dZglnnLWgdF+g7kOeYMn7abCfFVSnh5vLqfDkrwnyIqt7Ag==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ta": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.26.1.tgz",
-      "integrity": "sha512-keeh+croa1TAirV9Fd3OQMo5IkAlTGNWTNweHbi/htYMX0MKOPYxyqg+VH2bml+57VY2aUj/WYgV/p3ATx9EfQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-th": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-th/-/lang-th-4.26.1.tgz",
-      "integrity": "sha512-2SWZhrln3rMw8/DsRc9yS5bi3qEdGfw2pq9Uejx/UYED5zvvL6kh9AiCJZT4k0wMBGEwWUV6HxJ0Pq/jOTHogg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-tl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.26.1.tgz",
-      "integrity": "sha512-AzmLtg28tm0VXCm0Q0EY3OtA3m4oYxaqh4VX6uhB4J+PoEsIkm0py12SJxMNIsh/r98pobCumH8KH9bvHQoCAg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-tr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tr/-/lang-tr-4.26.1.tgz",
-      "integrity": "sha512-p30uuXvE9pZeU/5XkrQfvxRgiAOBmP3EyBFGV/+P05PEogaqbsmmtVCgCnR63yeRvVnGbToPBPjRK3OO1y4AEQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-uk": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.26.1.tgz",
-      "integrity": "sha512-PVEvmlhvl6BL3e/Q4qjMPsnwON3cWEYvDh9dg+Si+sjD2Edu9tajolJKcQ6ZA4I8dXrld5xuXx+DEBH/uB4uWQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-zh": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-zh/-/lang-zh-4.26.1.tgz",
-      "integrity": "sha512-kwqeqeEgMAMvucVX9HNE1p6s/2APP23ZsS8Um/lNvtswb4gL5jjYF9kyCvRfqlPBQSWWdRv7wwcnNXOvXYkxcQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/language": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language/-/language-4.25.0.tgz",
-      "integrity": "sha512-tUF6QENoUQ/E26RYc32IgsttStSF9cNO4ySN+BQECn8VpjukWdwbMw073MlOLXzjfeobxa+3hCVrmPPcW+V3UA=="
-    },
-    "node_modules/@nlpjs/language-min": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.25.0.tgz",
-      "integrity": "sha512-g8jtbDbqtRm+dlD/1Vnb4VWfKbKteApEGVTqIMxYkk6N/HMhvLZ5J2svrxzrB98a/HZ0fb//YBfFgymnz9Oukg=="
-    },
-    "node_modules/@nlpjs/ner": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.27.0.tgz",
-      "integrity": "sha512-ptwkxriJdmgHSH9TfP10JQ1jviaSl2SupSFGUvTuWkuJhobQd3hbnlSq40V6XYvJNmqh9M9zEab/AKeghxYOTA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/neural": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/neural/-/neural-4.25.0.tgz",
-      "integrity": "sha512-Oz20denGiBe0DlQsS7lN4TNrATN1nXlHKc/HB6jJPegjVmgJVCugDaHwIGoV7qOWyA6F2fRRwOgD+quNT2gVpg=="
-    },
-    "node_modules/@nlpjs/nlg": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.26.1.tgz",
-      "integrity": "sha512-PCJWiZ7464ChXXUGvjBZIFtoqkC24Oy6X63HgQrSv+63svz22Y5Cmu1MYLk77Nb+4keWv+hKhFJKDkvJoOpBVg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlp/-/nlp-4.27.0.tgz",
-      "integrity": "sha512-q6X7sY6TYVnQRZJKF/6mfLFlNA5oRYLhgQ5k3i1IBqH9lbWTAZJr31w/dCf97HXaYaj+vJp3h0ucfNumme9EIw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/ner": "^4.27.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/slot": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/nlu": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.27.0.tgz",
-      "integrity": "sha512-j4DUdoXS/y/Xag6ysYXx7Ve8NBmUVViUSCJhj3r49+zGyYtyVAHuVcqSej5q0tJjn0JSMT+6+ip8klON1q8ixw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/request": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/request/-/request-4.25.0.tgz",
-      "integrity": "sha512-MPVYWfFZY03WyFL7GWkUkv8tw968OXsdxFSJEvjXHzhiCe/vAlPCWbvoR+VnoQTgzLHxs/KIF6sIF2s9AzsLmQ==",
-      "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0"
-      }
-    },
-    "node_modules/@nlpjs/sentiment": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.26.1.tgz",
-      "integrity": "sha512-U2WmcW3w6yDDO45+Y7v5e6DPQj8e0x+RUUePPyRu2uIZmUtIKG+qCPMWnNLMmYQZoSQEFxmMMlLcGDC7tN7o3w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/similarity": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/similarity/-/similarity-4.26.1.tgz",
-      "integrity": "sha512-QutSBFGo/huNuz60PgqCjub0oBd9S8MLrjme33U5GzxuSvToQzXtn9/ynIia8qDm009D09VXV+LPeNE4h7yuSg=="
-    },
-    "node_modules/@nlpjs/slot": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.26.1.tgz",
-      "integrity": "sha512-mK8EEy5O+mRGne822PIKMxHSFh8j+iC7hGJ6T31XdFsNhFEYXLI/0dmeBstZgTSKBTe27HNFgCCwuGb77u0o9w=="
-    },
-    "node_modules/@nlpjs/xtables": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/xtables/-/xtables-4.25.0.tgz",
-      "integrity": "sha512-+baCtMZIp+aDqODLQs8Wyyke5qUqQkL8AGWsZzwYuJV8S7xdW2+XklRnHnkFc3p3foC248TkzG5L8j9r6INOtg==",
-      "dependencies": {
-        "xlsx": "^0.18.0"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 8"
       }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@novel-segment/dict-loader-core": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@novel-segment/dict-loader-core/-/dict-loader-core-1.0.28.tgz",
+      "integrity": "sha512-o7XQilS3uzjR8qxjqI7wh9zM3I0K68qPjsTj7OTK6VHSZThtO5CORRxTx18OYRonFvHGMuppd/4ad1WnsjjG0g==",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/loader-line": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loader-line/-/loader-line-1.0.31.tgz",
+      "integrity": "sha512-iMvkC8oYiroBNyB4soyUj9hMLMeKM+Vz7g8hNvM2k/998BSo7R4ZReWBJ7LBWhaLSkRKfg7IH1UuHMtCTpdEng==",
+      "dependencies": {
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/loader-stopword": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loader-stopword/-/loader-stopword-1.0.28.tgz",
+      "integrity": "sha512-UxHd3pC1v0J4GdXcCxXSvbCqXHptUKb6xBkSRzfSrnHJoFfMagn3oPduP2GYkQGJ6HqPceZZNmSjG5e/tyLEMQ==",
+      "dependencies": {
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/loaders": {
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loaders/-/loaders-1.0.47.tgz",
+      "integrity": "sha512-Akoal+sM6B6RaDhONRREclCowbEwNrJuyM0AKnK836VsykNECIcWoAvos6iBwQbEVZLYinCVH/gMjj+hxsWK1A==",
+      "dependencies": {
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "@novel-segment/loader-line": "^1.0.31",
+        "@novel-segment/loader-stopword": "^1.0.28",
+        "@novel-segment/stream-loader-core": "^1.0.24",
+        "@novel-segment/types": "^1.0.11",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/postag": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@novel-segment/postag/-/postag-1.0.26.tgz",
+      "integrity": "sha512-msd/oImyQQF3ghUfWZhNXnqk6puxV7w9OTY82olZt5zh2bgUpXpGU3JeTslcqLqbGKDCuu6HLSE4Hy2IFgEuow==",
+      "dependencies": {
+        "ts-enum-util": "^4.0.2",
+        "ts-type": "^3.0.1",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/stream-loader-core": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@novel-segment/stream-loader-core/-/stream-loader-core-1.0.24.tgz",
+      "integrity": "sha512-MnMt4jweAjkYxcLjn8jwtN83ckWoCftynOie0VIGAt+nPsgjyzkFmvp8tWG1PNMO8v2YZo0731b5e8O8qx+6HQ==",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "split2": "^4.2.0",
+        "stream-pipe": "^1.0.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/stringify": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@novel-segment/stringify/-/stringify-1.0.14.tgz",
+      "integrity": "sha512-RcQjTtVh3hHLUfd2hhxfhQio9j4bunHc9JkH6+Ip2bsP1XuBSf4mjtL01l7H7WemP8qF+YTz8z94lkxVrGowjg==",
+      "dependencies": {
+        "@novel-segment/types": "^1.0.11",
+        "ts-type": "^3.0.1"
+      }
+    },
+    "node_modules/@novel-segment/table-blacklist": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-blacklist/-/table-blacklist-1.0.13.tgz",
+      "integrity": "sha512-P/lPDPMseujCOGy0IDxextRxRJiOWC+xqlaFHQTH8BE3RpimULmlE6YcUswBPwdRiBJNg0WVJ/KN+0n5x3FgGQ==",
+      "dependencies": {
+        "@novel-segment/table-line": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-core-abstract": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-core-abstract/-/table-core-abstract-1.0.16.tgz",
+      "integrity": "sha512-NlKDtAmw4dQqCc2ndQWpiII0To/zm2we2VeOa5UsJx4KQT8Q36Ss8l+g3EYF0wrRFvIg53YivXsPy3MOkUsC8A==",
+      "dependencies": {
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/types": "^1.0.11",
+        "lodash": "^4.17.21",
+        "ts-type": "^3.0.1"
+      }
+    },
+    "node_modules/@novel-segment/table-dict": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-dict/-/table-dict-1.0.16.tgz",
+      "integrity": "sha512-YohOPI4v9X2PYF3eo2vkivOZeFaGzATlmoMbFAFBYwJgtjNgR8pTzuicIv1LTfba4xTBjkDbLZ8UNVwCFqmGhw==",
+      "dependencies": {
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/table-core-abstract": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-line": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-line/-/table-line-1.0.16.tgz",
+      "integrity": "sha512-cb0W9slOkFDYlzuWHojV7ru6P5+ck6GCwXRSv+xtF/5htJuBgPuQIVR1tV9MCW8AEF2wcTOL7Y3d+oyTHqBg/A==",
+      "dependencies": {
+        "@novel-segment/loader-line": "^1.0.31",
+        "@novel-segment/table-core-abstract": "^1.0.16",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@novel-segment/table-stopword": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-stopword/-/table-stopword-1.0.13.tgz",
+      "integrity": "sha512-vxSa1P31cGXw4jJdTWvS+/dVwfPAR7e0t3KsIekkyixfo/4FMfINFhg0DbCJ0GaQ0h+yHZbp60dj6jerA7btAg==",
+      "dependencies": {
+        "@novel-segment/table-line": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-synonym": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-synonym/-/table-synonym-1.0.13.tgz",
+      "integrity": "sha512-WIO/XY/mhhLRUUyIZSvp2LG2U6NQWm/0VsHpTUKtV08d+Nyf5A2KtHOP8JefsNW8TDZPep5pQi3lA8sJPgJBSg==",
+      "dependencies": {
+        "@novel-segment/table-synonym-pangu": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-synonym-pangu": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-synonym-pangu/-/table-synonym-pangu-1.0.16.tgz",
+      "integrity": "sha512-aR/99s9K9r6tK91jPogl9ccULBTrgsxcuwPZTH0ViMViq3KHYboZa+SnmFP1MIjqcAwOUJDW/jP2wGC0qdhivg==",
+      "dependencies": {
+        "@novel-segment/table-core-abstract": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/types": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@novel-segment/types/-/types-1.0.11.tgz",
+      "integrity": "sha512-C2/xo0pONcetO7x759uuq2YfhkaUVZRuxvMnZxEL7FwJXnmdrw3xztjFlYeaDSuZWJTmrfOnv7jgWTLkI+iDTA=="
+    },
+    "node_modules/@novel-segment/util": {
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/@novel-segment/util/-/util-1.0.73.tgz",
+      "integrity": "sha512-NiRMOc7ncN4GOYPCySDe3HK4MFRCqXrbSQ0ImQ9k421NO3W7QMfwS54xR6bimK5aWuXerJwqEI+nVe7awUor1g==",
+      "dependencies": {
+        "@bluelovers/string-natural-compare": "^2.0.11",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2"
+      },
+      "peerDependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "cjk-conv": "*",
+        "str-util": "*",
+        "uni-string": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
+      "dependencies": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      },
+      "bin": {
+        "adler32": "bin/adler32.njs"
+      },
       "engines": {
         "node": ">=0.8"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/array-hyper-unique": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/array-hyper-unique/-/array-hyper-unique-2.1.4.tgz",
+      "integrity": "sha512-RVsGx2YpFGhGpgdkK7A0VjFQecVUCowpkQerGCsyXVRXHxccAlPPTDt9ueF/X7Zq/6z6duZ49i9WzTCzcnQygQ==",
+      "dependencies": {
+        "deep-eql": "= 4.0.0",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/async": {
@@ -666,6 +535,18 @@
         "lodash": "^4.17.14"
       }
     },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
@@ -674,10 +555,26 @@
         "node": "*"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -691,13 +588,74 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+    "node_modules/cfb/node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/chinese-parseint2": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/chinese-parseint2/-/chinese-parseint2-2.0.6.tgz",
+      "integrity": "sha512-OZNUZHJ29I4HLj1sz2m41vO2gk1xxZridWc3YW2FB6y7Mda6Si3fpPzcAFA5vst0ZQBDbBxIJxioK/FV7zrp/A=="
+    },
+    "node_modules/cjk-conv": {
+      "version": "1.2.143",
+      "resolved": "https://registry.npmjs.org/cjk-conv/-/cjk-conv-1.2.143.tgz",
+      "integrity": "sha512-6t2yH0AzthiKniIjMW2VVuld7APYiGfyMnkWDPacSwzR1t7EWKNpnqwrOQz4iGp90++O10DKL8pULcn1trqlcg==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-alias": "^1.0.41",
+        "@lazy-cjk/jp-table-comparison": "^1.0.29",
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/jp-table-voice": "^1.0.37",
+        "@lazy-cjk/novel-filename": "^1.0.50",
+        "@lazy-cjk/util": "^1.0.18",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "@lazy-cjk/zh-convert-table": "^1.0.23",
+        "@lazy-cjk/zh-slugify": "^1.0.86",
+        "@lazy-cjk/zh-table-alias": "^1.0.62",
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/class-proxy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/class-proxy/-/class-proxy-2.0.0.tgz",
+      "integrity": "sha512-BDQfDF/EThTivmMgaEpiwToj20nDzpXoverANmY7aJyTe2z4ss8ZRlFnWFkJqcMli9HvNDzO1+getFeoED/xZg=="
+    },
+    "node_modules/codepage": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha512-iz3zJLhlrg37/gYRWgEPkaFTtzmnEv1h+r7NgZum2lFElYQPi0/5bnmuDfODHxfp0INEfnRqyfyeIJDbb7ahRw==",
+      "dependencies": {
+        "commander": "~2.14.1",
+        "exit-on-epipe": "~1.0.1"
+      },
+      "bin": {
+        "codepage": "bin/codepage.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage/node_modules/commander": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+    },
+    "node_modules/commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
+    "node_modules/core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA=="
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -710,20 +668,47 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/crlf-normalize": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/crlf-normalize/-/crlf-normalize-1.0.19.tgz",
+      "integrity": "sha512-cpV1h7YwFtIA36NHtyWuMMMPGxUp6zrzxjRnFEDLh1ZH0SPNUqCWmM8RlKVycxvKHgZOxWXs3XxX/DAlBAjFzA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ts-type": ">=2"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.0.0.tgz",
+      "integrity": "sha512-GxJC5MOg2KyQlv6WiUF/VAnMj4MWnYiXo4oLgeptOELVoknyErb4Z8+5F/IM/K4g9/80YzzatxmWcyRwUseH0A==",
+      "dependencies": {
+        "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deepmerge-plus": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/deepmerge-plus/-/deepmerge-plus-2.1.3.tgz",
+      "integrity": "sha512-nmRWdc9y7aqrhnZ1bWA+LOQuMV9WY6roWrZ7HN86l+JQ4HYRKXSQwOTNHseU88Py/knsov4j5Qh5RuFqCsNN8g==",
+      "dependencies": {
+        "is-mergeable-object": "1.1.0"
       },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/doublearray": {
@@ -731,21 +716,35 @@
       "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
       "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw=="
     },
+    "node_modules/emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
+    },
+    "node_modules/es6-class-prototype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es6-class-prototype/-/es6-class-prototype-2.0.0.tgz",
+      "integrity": "sha512-nn4YicqIBGRYIf8n/k45/iMfEZY8VVEW3jSeKWE9UTojR2evH1nl5fsJ9Cu7ZYZGUWaqZbXDyXMHk+e8ekw7Aw==",
+      "dependencies": {
+        "class-proxy": "^2.0.0"
+      }
+    },
     "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dependencies": {
         "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
         "esgenerate": "bin/esgenerate.js"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=4.0"
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
@@ -764,9 +763,9 @@
       }
     },
     "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "engines": {
         "node": ">=4.0"
       }
@@ -779,6 +778,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
@@ -787,35 +833,21 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
@@ -826,6 +858,46 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-mergeable-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.0.tgz",
+      "integrity": "sha512-JfyDDwUdtS4yHCgUpxOyKB9dnfZ0gecufxB0eytX6BmSXSE+8dbxDGt+V7CNRIRJ9sYFV/WQt2KJG6hNob2sBw=="
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/is-url": {
       "version": "1.2.4",
@@ -865,15 +937,77 @@
         "zlibjs": "^0.3.1"
       }
     },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "node_modules/lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A=="
+    },
+    "node_modules/lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ=="
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "node_modules/lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha512-SY0SwuPOHRwKcCNTdsntPYb+Zddz5mDUIVFABzRMqmAiL41pMeyoQFGxYAw5zdc9NnH4pbJqiqqp5ckfxa+zSA=="
+    },
+    "node_modules/lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha512-lsD+k73XztDsMBKPKvzHXRKFNMohTjoTKIIo4ADLn5dA65LZ1BqlAvSXhR2rPEC3BgAUQnzMnorqDtqn2z4IHA=="
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.12",
@@ -895,25 +1029,47 @@
       }
     },
     "node_modules/node-nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-4.27.0.tgz",
-      "integrity": "sha512-LnkhOUPXX0CMFbSzJ1gHI+7Yb3ULLip5gRsqedXb6pryjcRCbNzPgHXcH/6G9B1vSbDfO+y3X2B4QZpfP12OyQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-3.10.2.tgz",
+      "integrity": "sha512-xvTGtbNJNeCNX4zmhDhmyLoocRoEYPRiYBitiD6zptvUjzK9gpO3VXl08QNpKJQXNXvdUE50AecRTaDVM0i8DQ==",
       "dependencies": {
-        "@nlpjs/builtin-duckling": "^4.26.1",
-        "@nlpjs/builtin-microsoft": "^4.26.1",
-        "@nlpjs/core-loader": "^4.26.1",
-        "@nlpjs/emoji": "^4.26.1",
-        "@nlpjs/evaluator": "^4.26.1",
-        "@nlpjs/lang-all": "^4.26.1",
-        "@nlpjs/language": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlp": "^4.27.0",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/request": "^4.25.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/similarity": "^4.26.1",
-        "@nlpjs/xtables": "^4.25.0"
+        "@microsoft/recognizers-text-suite": "1.1.4",
+        "escodegen": "^1.12.0",
+        "esprima": "^4.0.1",
+        "kuromoji": "^0.1.2",
+        "novel-segment": "^2.5.0",
+        "xlsx": "^0.15.1"
+      }
+    },
+    "node_modules/novel-segment": {
+      "version": "2.7.108",
+      "resolved": "https://registry.npmjs.org/novel-segment/-/novel-segment-2.7.108.tgz",
+      "integrity": "sha512-O1WEuAhOr8KotCgX+wAuZkXlxFg/xJXhhtxVD2GhjJ7KnunCm4u2CmjbRhcuc3ABC9as/PAWTasKm7KkNT1Kyw==",
+      "dependencies": {
+        "@bluelovers/fast-glob": "^3.0.4",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "@novel-segment/postag": "^1.0.26",
+        "@novel-segment/stringify": "^1.0.14",
+        "@novel-segment/table-blacklist": "^1.0.13",
+        "@novel-segment/table-core-abstract": "^1.0.16",
+        "@novel-segment/table-dict": "^1.0.16",
+        "@novel-segment/table-stopword": "^1.0.13",
+        "@novel-segment/table-synonym": "^1.0.13",
+        "@novel-segment/types": "^1.0.11",
+        "array-hyper-unique": "^2.1.4",
+        "bluebird": "^3.7.2",
+        "cjk-conv": "^1.2.143",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "deepmerge-plus": "^2.1.3",
+        "regexp-cjk": "^3.3.110",
+        "segment-dict": "^2.3.194",
+        "sort-object-keys2": "^3.0.5",
+        "str-util": "^2.3.39",
+        "ts-enum-util": "4.0.2",
+        "ts-type": "^3.0.1",
+        "tslib": ">=2",
+        "uni-string": "^2.0.5"
       }
     },
     "node_modules/opencollective-postinstall": {
@@ -924,10 +1080,223 @@
         "opencollective-postinstall": "index.js"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "bin": {
+        "printj": "bin/printj.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/regexp-cjk": {
+      "version": "3.3.110",
+      "resolved": "https://registry.npmjs.org/regexp-cjk/-/regexp-cjk-3.3.110.tgz",
+      "integrity": "sha512-j8xVAGrxtah6YsFOaNqg9E+XhBwblzuvqDLdIHx2j5+cwJwhWAT06sd+zt4Eht3bmrGkJskffSUtEgnXPn8lnQ==",
+      "dependencies": {
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "array-hyper-unique": "^2.1.4",
+        "lodash": "^4.17.21",
+        "regexp-helper": "^1.0.37",
+        "regexp-parser-event": "^1.1.43",
+        "regexp-parser-literal": "^1.1.36",
+        "regexp-range": "^2.0.3",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexp-helper": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/regexp-helper/-/regexp-helper-1.0.37.tgz",
+      "integrity": "sha512-ljaT9d0l9tbvAnfQad9LajUOBYOJv6dG4ERN523rzoHHtqYsTDKpUX5TrMzzR4VYB/hUKO9nrF8x8EtOyJssoA==",
+      "dependencies": {
+        "regexp-helper-core": "^2.0.7",
+        "regexp-support": "^1.0.52",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexp-helper-core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/regexp-helper-core/-/regexp-helper-core-2.0.7.tgz",
+      "integrity": "sha512-Os9hhbLSriww8+83t5JQ/ZD2kSTXliPQ0OZ5zY4OYIrNiGI9gl2mBfGW7yoLdhFobN8V8UqI4GgM5LgpaiRNjQ=="
+    },
+    "node_modules/regexp-parser-event": {
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/regexp-parser-event/-/regexp-parser-event-1.1.43.tgz",
+      "integrity": "sha512-yGNjt4JLfhjjW4ApnPMgCSzfWjPEFORm9m8ePjMg1LaxU194e3Jd698wqE6xgIo7A/HrrlBIELJaYK0tNugxQg==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "regexp-parser-literal": "^1.1.36",
+        "regexpp2": "^1.3.32",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexp-parser-literal": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/regexp-parser-literal/-/regexp-parser-literal-1.1.36.tgz",
+      "integrity": "sha512-voha1jKjL9fpoX+YT/5SSTT5MqZR+X909WTA5umRdBLO1ifU2K0uJYA1EcWAh4PL2wMDH8b8Fv2Iq/Znh/eVtw==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "emoji-regex": "^10.2.1",
+        "regexpp2": "^1.3.32",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/regexp-range": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/regexp-range/-/regexp-range-2.0.3.tgz",
+      "integrity": "sha512-DdhZLQrwdEvOUSrJ6dttQYkZUr3ePn/AVacMgGpe9vRUDwGokgd5PtjryzY+DetZmo488JnEZQRWJDgKObKwMg==",
+      "dependencies": {
+        "@bluelovers/fill-range": "^7.0.2",
+        "@lazy-cjk/regexp-range-table": "^1.0.4",
+        "array-hyper-unique": "^2.1.4"
+      }
+    },
+    "node_modules/regexp-support": {
+      "version": "1.0.52",
+      "resolved": "https://registry.npmjs.org/regexp-support/-/regexp-support-1.0.52.tgz",
+      "integrity": "sha512-xrQ04NSjNZuUycj60MavZm3johOZSpob/lOKdu2lPPM/NPXeGxqN70bl8VmlkL16Bltf760ACPGBxbpD0SE+2g==",
+      "dependencies": {
+        "sort-object-keys2": "^3.0.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexpp2": {
+      "version": "1.3.32",
+      "resolved": "https://registry.npmjs.org/regexpp2/-/regexpp2-1.3.32.tgz",
+      "integrity": "sha512-vVwdpd23k3459hqLaEB2JeKhGM7fuuqVhWzT9ltdEXLC00yf7jcWltJxl0nM0tj2pLre90kXzJT6NvWdbc/6AA==",
+      "dependencies": {
+        "tslib": ">=2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/runes2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/runes2/-/runes2-1.1.2.tgz",
+      "integrity": "sha512-v6XIdRpUKdFLNhgF2AC9XvntZsDzxyTpVlpQ8HD592XD6vHiW8jEcHFnTV5ztUjWJC5cGOcdi9YKIwxWVh0f9w=="
+    },
+    "node_modules/segment-dict": {
+      "version": "2.3.194",
+      "resolved": "https://registry.npmjs.org/segment-dict/-/segment-dict-2.3.194.tgz",
+      "integrity": "sha512-/Pj6Z8mMm4oyzmxseRX58kt7AXOlhSjTp9A8uynnPiejJu7dsXizOi7igHlTWbA7ZDS0VWgKj2n8nv078RtZlQ==",
+      "dependencies": {
+        "@bluelovers/fast-glob": "^3.0.4",
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "@novel-segment/loader-stopword": "^1.0.28",
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/stream-loader-core": "^1.0.24",
+        "@novel-segment/util": "^1.0.73",
+        "bluebird": "^3.7.2",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "tslib": ">=2"
+      },
+      "peerDependencies": {
+        "novel-segment": "^2.7.103"
+      }
+    },
+    "node_modules/sort-object-keys2": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/sort-object-keys2/-/sort-object-keys2-3.0.5.tgz",
+      "integrity": "sha512-Q5fNSFbM4xXeTp1OtH62o67j+gzr2jPhZE0ES9bspDS26ScYfc2z5fL2vyRfVs947pkXCTS95Z/73lcbXuSJfg==",
+      "dependencies": {
+        "@lazy-array/util-unique": "^1.0.4"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -938,15 +1307,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.3.tgz",
+      "integrity": "sha512-pRuUdW0WwyB2doSqqjWyzwCD6PkfxpHAHdZp39K3dp/Hq7f+xfMwNAWIi16DyrRg4gg9c/RvLYkJTSawTPTm1w==",
       "dependencies": {
         "frac": "~1.1.2"
       },
+      "bin": {
+        "ssf": "bin/ssf.njs"
+      },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/str-util": {
+      "version": "2.3.40",
+      "resolved": "https://registry.npmjs.org/str-util/-/str-util-2.3.40.tgz",
+      "integrity": "sha512-wbrS5y0PAh+HtO7/3AESP6wfszS1QcBymTqjg1NwnA8W5NbqznwAt7l7rmpBHOupiVHmT8XWtR7skU3Qeqk3aQ==",
+      "dependencies": {
+        "@lazy-cjk/japanese": "^1.2.33",
+        "chinese-parseint2": "^2.0.6",
+        "cjk-conv": ">=1",
+        "deepmerge": "^4.3.1",
+        "is-fullwidth-code-point": "<4 >=3",
+        "strip-ansi": "<7 >=6",
+        "tslib": "^2",
+        "uni-string": "^2.0.5"
+      }
+    },
+    "node_modules/stream-pipe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-pipe/-/stream-pipe-1.0.4.tgz",
+      "integrity": "sha512-B60m1SSbH4yc7CTRj46hIu7/iDboTdurqEpXgzMxZMClTl2VCegn1lMr7OK0MTnRR3ziFpr7z5t15xUP31cqlw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/string-natural-compare2": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-natural-compare2/-/string-natural-compare2-3.0.1.tgz",
+      "integrity": "sha512-2g5OCprlirAeevzB1hmxas7fFhXQpAH12uJrU7/+DSSk+KRw6hO9h+XW5CwFjnzxa0FRNYvrGtb0WvXDjEME5g=="
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tesseract.js": {
@@ -977,10 +1396,83 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-enum-util": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ts-enum-util/-/ts-enum-util-4.0.2.tgz",
+      "integrity": "sha512-BB5qjvHYgYgOB/CaoA1Cy/B2QNnZ+nVBrJ15VV/AXGWx+AO83k5wgeLOJvkSLoKKavvH/M8Wj4ZbgROjsuYwzw=="
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "peer": true
+    },
+    "node_modules/ts-type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-3.0.1.tgz",
+      "integrity": "sha512-cleRydCkBGBFQ4KAvLH0ARIkciduS745prkGVVxPGvcRGhMMoSJUB7gNR1ByKhFTEYrYRg2CsMRGYnqp+6op+g==",
+      "dependencies": {
+        "@types/node": "*",
+        "tslib": ">=2",
+        "typedarray-dts": "^1.0.0"
+      },
+      "peerDependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA=="
+    },
+    "node_modules/uni-string": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uni-string/-/uni-string-2.0.5.tgz",
+      "integrity": "sha512-P2trBOQaqy9hiBtfkpn0MxripLhQqGua1Qy9cshYlVRIChUP6SmFhILWAsRWPhsWhGAWC8ymVYXr+vOKkyWALg==",
+      "dependencies": {
+        "es6-class-prototype": "^2.0.0",
+        "runes2": "^1.1.2"
+      }
     },
     "node_modules/wasm-feature-detect": {
       "version": "1.5.1",
@@ -1009,26 +1501,27 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "engines": {
-        "node": ">=0.8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.15.6.tgz",
+      "integrity": "sha512-7vD9eutyLs65iDjNFimVN+gk/oDkfkCgpQUjdE82QgzJCrBHC4bGPH7fzKVyy0UPp3gyFVQTQEFJaWaAvZCShQ==",
       "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.14.0",
+        "commander": "~2.17.1",
+        "crc-32": "~1.2.0",
+        "exit-on-epipe": "~1.0.1",
+        "ssf": "~0.10.3",
+        "wmf": "~1.0.1"
       },
       "bin": {
         "xlsx": "bin/xlsx.njs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,76 +11,270 @@
       "dependencies": {
         "bignumber.js": "^9.1.1",
         "JSONStream": "^1.3.5",
-        "node-nlp": "^4.27.0",
+        "node-nlp": "^3.10.2",
         "tesseract.js": "^4.1.1"
       }
     },
-    "node_modules/@microsoft/recognizers-text": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.3.1.tgz",
-      "integrity": "sha512-HikLoRUgSzM4OKP3JVBzUUp3Q7L4wgI17p/3rERF01HVmopcujY3i6wgx8PenCwbenyTNxjr1AwSDSVuFlYedQ==",
+    "node_modules/@bluelovers/fast-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bluelovers/fast-glob/-/fast-glob-3.0.4.tgz",
+      "integrity": "sha512-djAOOjDWXolYArm5NXxOIX7Q7OGhAaRtMs5F968OxelWkMUU6PyU6tS66CFykVON4U5y8jXcsnVAFCaeuf1nEA==",
+      "dependencies": {
+        "bluebird": "^3",
+        "fast-glob": "^3"
+      }
+    },
+    "node_modules/@bluelovers/fill-range": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@bluelovers/fill-range/-/fill-range-7.0.2.tgz",
+      "integrity": "sha512-KBuuuw6L/FoRUEhgpwM3z5wJ2Zo4ociL5hb7D/B4LDhe5U0Z3CL53i1+c1fcUXx1wExLyA77wtvzK5j+qEigyw==",
+      "dependencies": {
+        "@bluelovers/to-regex-range2": "^5.0.1"
+      },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@bluelovers/string-natural-compare": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@bluelovers/string-natural-compare/-/string-natural-compare-2.0.11.tgz",
+      "integrity": "sha512-k2KanWgqg6scH37zI7xd/5jFdFWg+V6Z9P1sl3RxrA855AFLbcFeAJMGMN8Dop547MUh5Tq3KKVttvE8DY5yUA==",
+      "dependencies": {
+        "string-natural-compare2": "^3.0.1"
+      }
+    },
+    "node_modules/@bluelovers/to-regex-range2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@bluelovers/to-regex-range2/-/to-regex-range2-5.0.1.tgz",
+      "integrity": "sha512-0fVn7EqIBAZjlnyzz87E5JUs0H+4KwW/i2RVzWRbcjb+xBxD0TIvRGUYGrfvb5eiQf0cuJn4F/zkTmd0cgrA0g==",
+      "dependencies": {
+        "@lazy-assert/check-basic": "^1.0.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@lazy-array/util-unique": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lazy-array/util-unique/-/util-unique-1.0.4.tgz",
+      "integrity": "sha512-zSffxqZZ8VhO068JG+HlYaUJC5ciCdyJnuUYysntTObrwLsA5bS+A09vhSVZ/On8ft+bOMYoAhAZOTw9Y0q70g=="
+    },
+    "node_modules/@lazy-assert/check-basic": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@lazy-assert/check-basic/-/check-basic-1.0.12.tgz",
+      "integrity": "sha512-Zttg9K7CBNcNlGDM+AQ9rqschYJ0c8tvJ/35iBuiqefZ9RuaW9C1Ww0AGgp9MVLL/h1/uBbY6CDuz+VRzCDDAg=="
+    },
+    "node_modules/@lazy-cjk/japanese": {
+      "version": "1.2.33",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/japanese/-/japanese-1.2.33.tgz",
+      "integrity": "sha512-n5M/eL6QQd1i/JH3cZ4L2Z3WkeNOXfIUlLt21Zvi4o1YGpth2Nf4OLVuPp/SwYYOpFfaN6JT9YkJ49ZOuIAKgA==",
+      "dependencies": {
+        "big.js": "^6.2.1",
+        "lodash": "^4.17.21",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-alias": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-alias/-/jp-table-alias-1.0.41.tgz",
+      "integrity": "sha512-Sv0vw0JhJqtYEhF5HgQVQ+eSRSejFCUdcHEafstaMCQ3juVaVSfe6b4LOj339+rucUEduBznnMy6LqXMp7MJ7A==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-comparison": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-comparison/-/jp-table-comparison-1.0.29.tgz",
+      "integrity": "sha512-yy+KrAk9ORhjJHB3VOWiQ/Wrx+CGP2PwCjixqRuw7xU1v2p8QRSiDAcPvh1FX+ObD/fenRq09NMEAw3X8pJlJg==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-convert": {
+      "version": "1.0.46",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-convert/-/jp-table-convert-1.0.46.tgz",
+      "integrity": "sha512-VhOGMBm1WGh0rUNCwJmVKPIuXVV5KcOqvynrwZUm7HJ6zsccNDPR7PsxFX0L5uS0xC7JdKgjlr2WrmgzY5lXGA==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-comparison": "^1.0.29",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/jp-table-voice": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-voice/-/jp-table-voice-1.0.37.tgz",
+      "integrity": "sha512-v1fnb1gBsjJ6fm2dQdFflH9gfQimg8tD6MoIpqlgaAiOTMtLina+MnmFoIw39WZp1ARiHAXqvO4Z6DgZRmp+2g==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/novel-filename": {
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/novel-filename/-/novel-filename-1.0.50.tgz",
+      "integrity": "sha512-msjq8cXWGz8VZVGW5TR5+1MfH6RN73NZzPmv6yfzAZ04TJsQqAy0qvkRfl9oGYfxdIoly7tzq0TSf81VKh40Xg==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/regexp-range-table": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/regexp-range-table/-/regexp-range-table-1.0.4.tgz",
+      "integrity": "sha512-Awt1XSFQQjxEgHORhJPkMfbPpxs2cvQXDFXqpK0fXYy3OyhJDUzZMS8wEWhf208kbbMefEWmVtbC2T2E+GagvQ=="
+    },
+    "node_modules/@lazy-cjk/static-build-zh-convert": {
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/static-build-zh-convert/-/static-build-zh-convert-1.0.51.tgz",
+      "integrity": "sha512-COEoNSL/wX08D2Epf8sItnSMFA9t2/imYJM5N+sglLY0sWaWM9T/bNcBAQTpLggslmylUX/IOZ14XxbJjkmzPg==",
+      "dependencies": {
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/util": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/util/-/util-1.0.18.tgz",
+      "integrity": "sha512-5Hxm60wBaulhBQmOeAOdvNky/BRTckeo/nZFS/SwOr9mPdczn6NHn4Nqbk4XMqZCvBbOBFnren85MKo5y/UsbQ==",
+      "dependencies": {
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-convert": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-convert/-/zh-convert-1.0.48.tgz",
+      "integrity": "sha512-yRf5K24JAtpysXYloI4FhLmzcdbDleR5T25/H7QHoz+Qx+lj86/Bf1Ta9mLnElv9liFgE0RWGEeppKs5rZqQzA==",
+      "dependencies": {
+        "@lazy-cjk/static-build-zh-convert": "^1.0.51",
+        "array-hyper-unique": "^2.1.4",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-convert-table": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-convert-table/-/zh-convert-table-1.0.23.tgz",
+      "integrity": "sha512-73kuMrTkwSEWeFI0ZI57JdIDBieh+yXk6s1A9NMBf1tgGnV2DR8c+BMVTalVDbhx8Skyh69iXawdP7/aeElfyw==",
+      "dependencies": {
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-slugify": {
+      "version": "1.0.86",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-slugify/-/zh-slugify-1.0.86.tgz",
+      "integrity": "sha512-P/xjZTsQYfCIv9qH6hlLvkuYxI3tpDVT9gPQ52+NkJrQyORZiJub+z4mmqBHf/ZXgo/+ZVeKzo8UCp6YT0LCUQ==",
+      "dependencies": {
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-table-alias": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-alias/-/zh-table-alias-1.0.62.tgz",
+      "integrity": "sha512-ppNQ4VGP+zaBGUGvXPeLANc8zy6Yi9r3pzVySB+ypy+n3C43QOpJJoWtIvEuKfmFGju4ZKO6CucCwEnf9U3mwQ==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-alias": "^1.0.41",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "array-hyper-unique": "^2.1.4",
+        "deepmerge-plus": "^2.1.3",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-table-greedy": {
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-greedy/-/zh-table-greedy-1.0.90.tgz",
+      "integrity": "sha512-ktk6dH9yuGPJEmEZtliYCNALbKO6jfmXjSFabnF1hgNW/uk2rg5r5nydyFXa4rECclSbk88xT0sXe2cBTOf30A==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@lazy-cjk/zh-table-list": {
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-list/-/zh-table-list-1.0.84.tgz",
+      "integrity": "sha512-xzzQf2rDSmovYT98gHTN2LXGITsy1NNIbu6Klp2zC2Tk0SjeUcRhMxJjVWQUtXBbBQ3UlSZKrTvutpRFjVja0g==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "@lazy-cjk/zh-table-alias": "^1.0.62",
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/@microsoft/recognizers-text": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
+      "integrity": "sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-choice": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.3.1.tgz",
-      "integrity": "sha512-HubunMJVq/OetmdvcAmBh5skMlg+yiScm3V2wNyNZIVvLgli4+8nzbg/W/fI9dpaf6wv9ZQ7d2IYvn8swJBo3A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.4.tgz",
+      "integrity": "sha512-4CddwFe4RVhZeJgW65ocBrEdeukBMghK8pgI0K0Qy2eA5ysPZQpeZ7BGSDz5QMQei5LPY+QaAQ3CHU+ORHoO7A==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "grapheme-splitter": "^1.0.2"
       },
       "engines": {
-        "node": ">=10.3.0"
-      }
-    },
-    "node_modules/@microsoft/recognizers-text-data-types-timex-expression": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.3.1.tgz",
-      "integrity": "sha512-jarJIFIJZBqeofy3hh0vdQo1yOmTM+jCjj6/zmo9JunsQ6LO750eZHCg9eLptQhsvq321XCt5xdRNLCwU8YeNA==",
-      "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-date-time": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.3.2.tgz",
-      "integrity": "sha512-fUEGOTccS55ZY0erzjS1bunJYA9lGXjcZoru5oPOlnxbJS4Lk0ylgdH2Ub2EjAyqr8DIJhdLNOEesCdAXMvlNg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.4.tgz",
+      "integrity": "sha512-leMnjN+KYNwNvRD5T4G0ORUzkjlek/BBZDvQIjAujtyrd/pkViUnuouWIPkFT/dbSOxXML8et54CSk2KfHiWIA==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
-        "@microsoft/recognizers-text-number": "~1.3.1",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.1",
-        "lodash": "^4.17.21"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "lodash.isequal": "^4.5.0",
+        "lodash.tonumber": "^4.0.3"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-number": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.3.1.tgz",
-      "integrity": "sha512-JBxhSdihdQLQilCtqISEBw5kM+CNGTXzy5j5hNoZECNUEvBUPkAGNEJAeQPMP5abrYks29aSklnSvSyLObXaNQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.4.tgz",
+      "integrity": "sha512-6EmlR+HR+eJBIX7sQby1vs6LJB64wxLowHaGpIU9OCXFvZ5Nb0QT8qh10rC40v3Mtrz4DpScXfSXr9tWkIO5MQ==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "bignumber.js": "^7.2.1",
-        "lodash": "^4.17.21"
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.sortby": "^4.7.0",
+        "lodash.trimend": "^4.5.1"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-number-with-unit": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.3.1.tgz",
-      "integrity": "sha512-gzCpPP4zQ5Vb+RHaWjzP2t1c+mj6GYOsFoI2NyJkm8OZ52XI+x9SJCgrrD2ujzjOd5/CQVC46rE22rfGwXLDkA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz",
+      "integrity": "sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
-        "@microsoft/recognizers-text-number": "~1.3.1",
-        "lodash": "^4.17.21"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.last": "^3.0.0",
+        "lodash.max": "^4.0.1"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-number/node_modules/bignumber.js": {
@@ -92,581 +286,256 @@
       }
     },
     "node_modules/@microsoft/recognizers-text-sequence": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.3.1.tgz",
-      "integrity": "sha512-J7Kg35hpm0NcFHmu69Bb4q7DPDiSpCd8ApUZqNm59itIjrQJHpSdl9HF6JxuQQz0Ftc/li5ZLqSuupJAmA/sgg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
+      "integrity": "sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "grapheme-splitter": "^1.0.2"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@microsoft/recognizers-text-suite": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.3.0.tgz",
-      "integrity": "sha512-uqG4vzy5N2CmBaeINny0bLdnGp0jDbT1moNoLC+Yim3G8kHOU9lpDfwA6VN6HTYaDM5854SNMEzLjJdS1TPFTw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.4.tgz",
+      "integrity": "sha512-hNIaR4M2G0nNeI9WZxt9C0KYh/1vhjeKzX5Ds8XDdT0pxF7zwCSo19WNcPjrVK6aCOeZTw/ULofsAjdu9gSkcA==",
       "dependencies": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "@microsoft/recognizers-text-choice": "~1.3.0",
-        "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
-        "@microsoft/recognizers-text-date-time": "~1.3.0",
-        "@microsoft/recognizers-text-number": "~1.3.0",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-        "@microsoft/recognizers-text-sequence": "~1.3.0"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-choice": "~1.1.4",
+        "@microsoft/recognizers-text-date-time": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "@microsoft/recognizers-text-sequence": "~1.1.4"
       },
       "engines": {
-        "node": ">=10.3.0"
+        "node": ">=6.0.0"
       }
     },
-    "node_modules/@nlpjs/builtin-duckling": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-duckling/-/builtin-duckling-4.26.1.tgz",
-      "integrity": "sha512-3qkH955X2g5MXV1EqT3fTAT/lLEdiqqe5IgBDyr+MQB7FOV9R3YhqGIn3DFOl+TSm/tP5n/BAEptkTNn/TOpmQ==",
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/builtin-microsoft": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-microsoft/-/builtin-microsoft-4.26.1.tgz",
-      "integrity": "sha512-AODgzTcfYUf5Ozm00aQnHImDum7Idtl0F9dSPoaXpfj7rZqP8hPZ7iWwdGTAvISH/da2YhjPOU65QSYk2YpjFA==",
-      "dependencies": {
-        "@microsoft/recognizers-text-suite": "1.3.0",
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/core": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.26.1.tgz",
-      "integrity": "sha512-M/PeFddsi3y7Z1piFJxsLGm5/xdMhcrpOsml7s6CTEgYo8iduaT30HDd61tZxDyvvJseU6uFqlXSn7XKkAcC1g=="
-    },
-    "node_modules/@nlpjs/core-loader": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core-loader/-/core-loader-4.26.1.tgz",
-      "integrity": "sha512-IiRtn65bdiUSQHy2kusco2fmhk39u2Mc2c5Fsm9+9EVG6BtJCmVEFU/btAzGDAmxEA/E4qKecaAT4LvcW6TPbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/request": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/emoji": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/emoji/-/emoji-4.26.1.tgz",
-      "integrity": "sha512-Q0PoXwIvaB1bnRXK4U/YD7mrqaz29Yfed3s2au0iXl1bffUgoG+hs4GORCvyy7DFCCLlc9d5yDM3oLIX/ggZ+Q==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/evaluator": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/evaluator/-/evaluator-4.26.1.tgz",
-      "integrity": "sha512-WeUrC8qq7+V8Jhkkjc2yiXdzy9V0wbETv8/qasQmL0QmEuwBDJF+fvfl4z2vWpBb0vW07A8aNrFElKELzbpkdg==",
-      "dependencies": {
-        "escodegen": "^2.0.0",
-        "esprima": "^4.0.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-all": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.26.1.tgz",
-      "integrity": "sha512-UzRm1JRRAyQqilEOxQ2ySMOitKbhPk5iKYbjD8FREDcPjreUvDxVuQsYUOvYucmEyFcZU2U/TdJx+fX9/bcaKQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-ar": "^4.26.1",
-        "@nlpjs/lang-bn": "^4.26.1",
-        "@nlpjs/lang-ca": "^4.26.1",
-        "@nlpjs/lang-cs": "^4.26.1",
-        "@nlpjs/lang-da": "^4.26.1",
-        "@nlpjs/lang-de": "^4.26.1",
-        "@nlpjs/lang-el": "^4.26.1",
-        "@nlpjs/lang-en": "^4.26.1",
-        "@nlpjs/lang-es": "^4.26.1",
-        "@nlpjs/lang-eu": "^4.26.1",
-        "@nlpjs/lang-fa": "^4.26.1",
-        "@nlpjs/lang-fi": "^4.26.1",
-        "@nlpjs/lang-fr": "^4.26.1",
-        "@nlpjs/lang-ga": "^4.26.1",
-        "@nlpjs/lang-gl": "^4.26.1",
-        "@nlpjs/lang-hi": "^4.26.1",
-        "@nlpjs/lang-hu": "^4.26.1",
-        "@nlpjs/lang-hy": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1",
-        "@nlpjs/lang-it": "^4.26.1",
-        "@nlpjs/lang-ja": "^4.26.1",
-        "@nlpjs/lang-ko": "^4.26.1",
-        "@nlpjs/lang-lt": "^4.26.1",
-        "@nlpjs/lang-ms": "^4.26.1",
-        "@nlpjs/lang-ne": "^4.26.1",
-        "@nlpjs/lang-nl": "^4.26.1",
-        "@nlpjs/lang-no": "^4.26.1",
-        "@nlpjs/lang-pl": "^4.26.1",
-        "@nlpjs/lang-pt": "^4.26.1",
-        "@nlpjs/lang-ro": "^4.26.1",
-        "@nlpjs/lang-ru": "^4.26.1",
-        "@nlpjs/lang-sl": "^4.26.1",
-        "@nlpjs/lang-sr": "^4.26.1",
-        "@nlpjs/lang-sv": "^4.26.1",
-        "@nlpjs/lang-ta": "^4.26.1",
-        "@nlpjs/lang-th": "^4.26.1",
-        "@nlpjs/lang-tl": "^4.26.1",
-        "@nlpjs/lang-tr": "^4.26.1",
-        "@nlpjs/lang-uk": "^4.26.1",
-        "@nlpjs/lang-zh": "^4.26.1",
-        "@nlpjs/language": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/lang-ar": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ar/-/lang-ar-4.26.1.tgz",
-      "integrity": "sha512-MUlVtabt9ltG7WyzCQpFJymLJlnEqp3mxhgN9JHyFH7oZMK3REvMovFfvEUAbfiYrJEv/BN5KKLL7yrvUeaHtg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-bn": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.26.1.tgz",
-      "integrity": "sha512-sim1iZKBDdehi/yBUKrLW51QvS9uB+sXW7lj+THVqBy5UsnEQvt4gzE0NsC873uJMh66vt2AlHkhzgPH0qH/nQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ca": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ca/-/lang-ca-4.26.1.tgz",
-      "integrity": "sha512-fD4R5tcAB0uYtNxSEF20b1KmF6nUQSbiJqrIUJI5yis4ObjCYRQnSh4bjVDKUKxyONjbD6L8EaK5GrY1/jkwFQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-cs": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.26.1.tgz",
-      "integrity": "sha512-CqI6VB8toaJ/MlP1D4K9BctA6GpZJhMKyEy+OX9xavDe4r4ao/SxlSaIYK3izK0k+J38lJWC5lXYGazfCdTGjA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-da": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-da/-/lang-da-4.26.1.tgz",
-      "integrity": "sha512-krI/ojeDSi329ENM/hLIsbUh1x4XRTKAbtPcbFxAY6XVhcSVoWPO7L77jFTL1NQeE1oGRFzGHaeC9hZJ8phVbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-de": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.26.1.tgz",
-      "integrity": "sha512-HfZQwsE5FICq9taVZDiyktmdAePVF5948NM80et0d9mx43RWDFhHKQYgtJPwfQXtdCoQtOM5TOJ2FanGwzPeaA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-el": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-el/-/lang-el-4.26.1.tgz",
-      "integrity": "sha512-pcOvuSwPCXxI+2xNZZzM4V5pTRDntYoJi0SP/ic2nV4IPQ0nU2j16dYfg1HlvET/E6iN1VTqghrCaf10SMkDGA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-en": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en/-/lang-en-4.26.1.tgz",
-      "integrity": "sha512-GVoJpOjyk5TtBAqo/fxsiuuH7jXycyakGT0gw5f01u9lOmUnpJegvXyGff/Nb0j14pXcGHXOhmpWrcTrG2B0LQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-en-min": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-en-min": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.26.1.tgz",
-      "integrity": "sha512-1sJZ7dy7ysqzbsB8IklguvB88J8EPIv4XGVkZCcwecKtOw+fp5LAsZ3TJVmEf18iK1gD4cEGr7qZg5fpPxTpWQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-es": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.26.1.tgz",
-      "integrity": "sha512-fIPQt+WPcNdyxZOCMkOPlMb4Y1iE585QxjB9IAdFz8ZtVg7mc4dlv5f46ud7ppdMh84iLOuOdo6pzu2Cqm14lw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-eu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-eu/-/lang-eu-4.26.1.tgz",
-      "integrity": "sha512-Ha8GHTbgQYd7dwHM8aWHDyxmbUNUcyu/5xlBKqqBOPxysDyZ6Ad0tvj0FmJBy6mYhqmFTPBnEAo69cfuFSqWIQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fa": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.26.1.tgz",
-      "integrity": "sha512-qJCmNXgJZnfNXUnKnxvEGEzSFBdQT4XU7/rMxuFmSJqmQY7fH/Vsmi5CKF94VRBPOIV4ULlEJuLpUWHXRmOnVQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fi/-/lang-fi-4.26.1.tgz",
-      "integrity": "sha512-W/rUcrzSh3KE07q2vOsssTpU1sbX32gbBzKPZfRJ2ZUF4afO+eHxmAywikXubP4kiU3JxVNLvXXEjuGD3SBUbA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-fr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.26.1.tgz",
-      "integrity": "sha512-LTA852atCJnHtKDmtjx/ui5AnvEIkrPx+MJQ2mB3gn8ko6i2UITnJgPmJE9Kej5bLasVZOAJvU/SrfXEmnPGOw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ga": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ga/-/lang-ga-4.26.1.tgz",
-      "integrity": "sha512-JsP1CZ8r3Jd6o/Az7cN3exz0HDP3FNYLzh4Vi6ksEkdKF0yCjJ9G5dXZYqS9qFIN5ffemWn29G4WRELY6QH/cQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-gl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.26.1.tgz",
-      "integrity": "sha512-y1NNu6NVy/6o5UNfihgg0WkSlVr4IvKA5W193CpRLZWS4FccQDmnFFhyYWRkshyDbgEsfsZ0Rs3BoE82+T2Ubg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hi/-/lang-hi-4.26.1.tgz",
-      "integrity": "sha512-Fw9rXqF5l8q9etJG5uOlEFpnMVjQEWMaCIgQfEcA1yTvieSV8mpoSvQkEZl+DFhww+azareoJ7ZCkx0gJ9UDuQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.26.1.tgz",
-      "integrity": "sha512-7dPUn5/ZpLZmsdRwO+dtORuMIiIpnsWbgSLIKdOLh8irhgUR+M2bYTfkdnKcrEcHzHPP8Svn7pU0xk7OKSUA1w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-hy": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hy/-/lang-hy-4.26.1.tgz",
-      "integrity": "sha512-T2brpLGDJryAwWmjtnmY8Ot6ZUkCz+/nRR9/QM1PybvZIqOVLjJqA49bqjJfT5DMN89HbwC7I/15NTT0y09i1Q==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-id": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.26.1.tgz",
-      "integrity": "sha512-rVuIkYFKdltFhMT/a2ZxD9ovoZSVZF7OPuqYjTXW9xKd3Ff32yUrzcf/pHXlqmZOSltqOH3E5jZRRDkHvgUOjQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-it": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-it/-/lang-it-4.26.1.tgz",
-      "integrity": "sha512-BZA3QnfQGW91gYaybRmHnCAPBvQggtmHZJrAmuBZUKUS12HoQm8uybjw2fZO+vahEeUQceKNDISRcT1eLLijog==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ja": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.26.1.tgz",
-      "integrity": "sha512-QgkuJOkHguRFyfnckH2It5/Kg8zecnOMJsHxYeuDC4tBF7jL/5xqWis+679lYLsXtAkrG8+fjVcBbjyopP0KHg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "kuromoji": "^0.1.2"
-      }
-    },
-    "node_modules/@nlpjs/lang-ko": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ko/-/lang-ko-4.26.1.tgz",
-      "integrity": "sha512-Q0N8bLJJ829ILWCKH1UQWPSNyuLaEURAXCawkDju4pt33DBLcpqz9IzO9dnqiFc+fjSgVzZ7WMaLT18hXZQ9vg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-lt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.26.1.tgz",
-      "integrity": "sha512-SeYZxRhdCy+ClQNnF/u0MAtcDui/ocdk4NtgNOCuwNTNuzhN3t3rfGeArfBGmZeg1SIeBLUDE9dsTxYCv5AOEg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ms": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ms/-/lang-ms-4.26.1.tgz",
-      "integrity": "sha512-KxWBS+tFY2U8z9UrjQIqMM40npGDOskP5DcWhaEE3zuhzf3RTDYjy8sdz34jVd0fBdbPihX133h3bFibg2Cm7w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ne": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.26.1.tgz",
-      "integrity": "sha512-K3E2l+0LTESv+dO+ZTIdvNa+zwMJvvnMiFYYkKvJst6lhc8JgvGOsPxGsjJn6PDhI3wyfQu+dg3b+bnVPu4FDA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-nl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-nl/-/lang-nl-4.26.1.tgz",
-      "integrity": "sha512-I/mP1RRbUN4BQ+8NXAl2FKaLHbb7f6S8JVjxHQ0sKHT4BgQ3+r0yO+DVcEsHg+vWRiY1Fyzh0gq0PhLVnF6HnA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-no": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.26.1.tgz",
-      "integrity": "sha512-a0CLL2c/OCzbg7J7ugyrsAksI96XhkQ3IeBbbx60o5o/9wsFNik6cPWrkpoE5xNtw7gLlAJWabwDiZXkl8Zrcw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-pl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pl/-/lang-pl-4.26.1.tgz",
-      "integrity": "sha512-nrDXlq+TzQLE5IpXPIlFMzd8OpquvApWsouh6fmLsD9HZLZI4O3w1M4sXXLzE+9Ggu9Cy1m1QJ0/i7XCcv115g==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-pt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.26.1.tgz",
-      "integrity": "sha512-p6yZHaJ0e+n0avMHpdDw5PMk4HkKXjPbOMbrlg0dF+VRqChjxfH478Q423rDyzu/4MzDsIYB+p6KzL9AARKXpg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ro": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ro/-/lang-ro-4.26.1.tgz",
-      "integrity": "sha512-baUdTA0DWpDR0Tn6fxo+RDN/6gbuINLCARtHwap2UR/HKQWP2XoH/DIvcjZpwUTalr5MQjso31epcdeRRapczA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ru": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.26.1.tgz",
-      "integrity": "sha512-NaZ2DAOGxWG2Us9IyIDs3m6vhGpUaUJRVgzzHHyX3LO3xEYjZmtnA0jEpBaTOe2PuNHThv0WCZUNn9BSurV3PA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sl/-/lang-sl-4.26.1.tgz",
-      "integrity": "sha512-QBJwcJt+oKUpAnHKNJkLkx9Xm1n4dUPC5GPYfAXTnJZf0hNWJSY21GicdWi7Vu/qFJ3ghIqtSP8D7KIPLnibNw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.26.1.tgz",
-      "integrity": "sha512-drH3+UqTW637uLWsnLrcp8jEKUGxV61ZgCBjNkVQNEv1/jbpSg6IqgynSY2JyhtnlV0f870KS0HvSbyo5AD4Ng==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-sv": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sv/-/lang-sv-4.26.1.tgz",
-      "integrity": "sha512-2axkrYFC02tAlxCWeiEKISbe4dSteciP1CIggO/dZglnnLWgdF+g7kOeYMn7abCfFVSnh5vLqfDkrwnyIqt7Ag==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-ta": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.26.1.tgz",
-      "integrity": "sha512-keeh+croa1TAirV9Fd3OQMo5IkAlTGNWTNweHbi/htYMX0MKOPYxyqg+VH2bml+57VY2aUj/WYgV/p3ATx9EfQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-th": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-th/-/lang-th-4.26.1.tgz",
-      "integrity": "sha512-2SWZhrln3rMw8/DsRc9yS5bi3qEdGfw2pq9Uejx/UYED5zvvL6kh9AiCJZT4k0wMBGEwWUV6HxJ0Pq/jOTHogg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-tl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.26.1.tgz",
-      "integrity": "sha512-AzmLtg28tm0VXCm0Q0EY3OtA3m4oYxaqh4VX6uhB4J+PoEsIkm0py12SJxMNIsh/r98pobCumH8KH9bvHQoCAg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-tr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tr/-/lang-tr-4.26.1.tgz",
-      "integrity": "sha512-p30uuXvE9pZeU/5XkrQfvxRgiAOBmP3EyBFGV/+P05PEogaqbsmmtVCgCnR63yeRvVnGbToPBPjRK3OO1y4AEQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-uk": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.26.1.tgz",
-      "integrity": "sha512-PVEvmlhvl6BL3e/Q4qjMPsnwON3cWEYvDh9dg+Si+sjD2Edu9tajolJKcQ6ZA4I8dXrld5xuXx+DEBH/uB4uWQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/lang-zh": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-zh/-/lang-zh-4.26.1.tgz",
-      "integrity": "sha512-kwqeqeEgMAMvucVX9HNE1p6s/2APP23ZsS8Um/lNvtswb4gL5jjYF9kyCvRfqlPBQSWWdRv7wwcnNXOvXYkxcQ==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/language": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language/-/language-4.25.0.tgz",
-      "integrity": "sha512-tUF6QENoUQ/E26RYc32IgsttStSF9cNO4ySN+BQECn8VpjukWdwbMw073MlOLXzjfeobxa+3hCVrmPPcW+V3UA=="
-    },
-    "node_modules/@nlpjs/language-min": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.25.0.tgz",
-      "integrity": "sha512-g8jtbDbqtRm+dlD/1Vnb4VWfKbKteApEGVTqIMxYkk6N/HMhvLZ5J2svrxzrB98a/HZ0fb//YBfFgymnz9Oukg=="
-    },
-    "node_modules/@nlpjs/ner": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.27.0.tgz",
-      "integrity": "sha512-ptwkxriJdmgHSH9TfP10JQ1jviaSl2SupSFGUvTuWkuJhobQd3hbnlSq40V6XYvJNmqh9M9zEab/AKeghxYOTA==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/neural": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/neural/-/neural-4.25.0.tgz",
-      "integrity": "sha512-Oz20denGiBe0DlQsS7lN4TNrATN1nXlHKc/HB6jJPegjVmgJVCugDaHwIGoV7qOWyA6F2fRRwOgD+quNT2gVpg=="
-    },
-    "node_modules/@nlpjs/nlg": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.26.1.tgz",
-      "integrity": "sha512-PCJWiZ7464ChXXUGvjBZIFtoqkC24Oy6X63HgQrSv+63svz22Y5Cmu1MYLk77Nb+4keWv+hKhFJKDkvJoOpBVg==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlp/-/nlp-4.27.0.tgz",
-      "integrity": "sha512-q6X7sY6TYVnQRZJKF/6mfLFlNA5oRYLhgQ5k3i1IBqH9lbWTAZJr31w/dCf97HXaYaj+vJp3h0ucfNumme9EIw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/ner": "^4.27.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/slot": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/nlu": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.27.0.tgz",
-      "integrity": "sha512-j4DUdoXS/y/Xag6ysYXx7Ve8NBmUVViUSCJhj3r49+zGyYtyVAHuVcqSej5q0tJjn0JSMT+6+ip8klON1q8ixw==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "node_modules/@nlpjs/request": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/request/-/request-4.25.0.tgz",
-      "integrity": "sha512-MPVYWfFZY03WyFL7GWkUkv8tw968OXsdxFSJEvjXHzhiCe/vAlPCWbvoR+VnoQTgzLHxs/KIF6sIF2s9AzsLmQ==",
-      "dependencies": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0"
-      }
-    },
-    "node_modules/@nlpjs/sentiment": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.26.1.tgz",
-      "integrity": "sha512-U2WmcW3w6yDDO45+Y7v5e6DPQj8e0x+RUUePPyRu2uIZmUtIKG+qCPMWnNLMmYQZoSQEFxmMMlLcGDC7tN7o3w==",
-      "dependencies": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0"
-      }
-    },
-    "node_modules/@nlpjs/similarity": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/similarity/-/similarity-4.26.1.tgz",
-      "integrity": "sha512-QutSBFGo/huNuz60PgqCjub0oBd9S8MLrjme33U5GzxuSvToQzXtn9/ynIia8qDm009D09VXV+LPeNE4h7yuSg=="
-    },
-    "node_modules/@nlpjs/slot": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.26.1.tgz",
-      "integrity": "sha512-mK8EEy5O+mRGne822PIKMxHSFh8j+iC7hGJ6T31XdFsNhFEYXLI/0dmeBstZgTSKBTe27HNFgCCwuGb77u0o9w=="
-    },
-    "node_modules/@nlpjs/xtables": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/xtables/-/xtables-4.25.0.tgz",
-      "integrity": "sha512-+baCtMZIp+aDqODLQs8Wyyke5qUqQkL8AGWsZzwYuJV8S7xdW2+XklRnHnkFc3p3foC248TkzG5L8j9r6INOtg==",
-      "dependencies": {
-        "xlsx": "^0.18.0"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 8"
       }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@novel-segment/dict-loader-core": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@novel-segment/dict-loader-core/-/dict-loader-core-1.0.28.tgz",
+      "integrity": "sha512-o7XQilS3uzjR8qxjqI7wh9zM3I0K68qPjsTj7OTK6VHSZThtO5CORRxTx18OYRonFvHGMuppd/4ad1WnsjjG0g==",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/loader-line": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loader-line/-/loader-line-1.0.31.tgz",
+      "integrity": "sha512-iMvkC8oYiroBNyB4soyUj9hMLMeKM+Vz7g8hNvM2k/998BSo7R4ZReWBJ7LBWhaLSkRKfg7IH1UuHMtCTpdEng==",
+      "dependencies": {
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/loader-stopword": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loader-stopword/-/loader-stopword-1.0.28.tgz",
+      "integrity": "sha512-UxHd3pC1v0J4GdXcCxXSvbCqXHptUKb6xBkSRzfSrnHJoFfMagn3oPduP2GYkQGJ6HqPceZZNmSjG5e/tyLEMQ==",
+      "dependencies": {
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/loaders": {
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loaders/-/loaders-1.0.47.tgz",
+      "integrity": "sha512-Akoal+sM6B6RaDhONRREclCowbEwNrJuyM0AKnK836VsykNECIcWoAvos6iBwQbEVZLYinCVH/gMjj+hxsWK1A==",
+      "dependencies": {
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "@novel-segment/loader-line": "^1.0.31",
+        "@novel-segment/loader-stopword": "^1.0.28",
+        "@novel-segment/stream-loader-core": "^1.0.24",
+        "@novel-segment/types": "^1.0.11",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/postag": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@novel-segment/postag/-/postag-1.0.26.tgz",
+      "integrity": "sha512-msd/oImyQQF3ghUfWZhNXnqk6puxV7w9OTY82olZt5zh2bgUpXpGU3JeTslcqLqbGKDCuu6HLSE4Hy2IFgEuow==",
+      "dependencies": {
+        "ts-enum-util": "^4.0.2",
+        "ts-type": "^3.0.1",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/stream-loader-core": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@novel-segment/stream-loader-core/-/stream-loader-core-1.0.24.tgz",
+      "integrity": "sha512-MnMt4jweAjkYxcLjn8jwtN83ckWoCftynOie0VIGAt+nPsgjyzkFmvp8tWG1PNMO8v2YZo0731b5e8O8qx+6HQ==",
+      "dependencies": {
+        "bluebird": "^3.7.2",
+        "split2": "^4.2.0",
+        "stream-pipe": "^1.0.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/@novel-segment/stringify": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@novel-segment/stringify/-/stringify-1.0.14.tgz",
+      "integrity": "sha512-RcQjTtVh3hHLUfd2hhxfhQio9j4bunHc9JkH6+Ip2bsP1XuBSf4mjtL01l7H7WemP8qF+YTz8z94lkxVrGowjg==",
+      "dependencies": {
+        "@novel-segment/types": "^1.0.11",
+        "ts-type": "^3.0.1"
+      }
+    },
+    "node_modules/@novel-segment/table-blacklist": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-blacklist/-/table-blacklist-1.0.13.tgz",
+      "integrity": "sha512-P/lPDPMseujCOGy0IDxextRxRJiOWC+xqlaFHQTH8BE3RpimULmlE6YcUswBPwdRiBJNg0WVJ/KN+0n5x3FgGQ==",
+      "dependencies": {
+        "@novel-segment/table-line": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-core-abstract": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-core-abstract/-/table-core-abstract-1.0.16.tgz",
+      "integrity": "sha512-NlKDtAmw4dQqCc2ndQWpiII0To/zm2we2VeOa5UsJx4KQT8Q36Ss8l+g3EYF0wrRFvIg53YivXsPy3MOkUsC8A==",
+      "dependencies": {
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/types": "^1.0.11",
+        "lodash": "^4.17.21",
+        "ts-type": "^3.0.1"
+      }
+    },
+    "node_modules/@novel-segment/table-dict": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-dict/-/table-dict-1.0.16.tgz",
+      "integrity": "sha512-YohOPI4v9X2PYF3eo2vkivOZeFaGzATlmoMbFAFBYwJgtjNgR8pTzuicIv1LTfba4xTBjkDbLZ8UNVwCFqmGhw==",
+      "dependencies": {
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/table-core-abstract": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-line": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-line/-/table-line-1.0.16.tgz",
+      "integrity": "sha512-cb0W9slOkFDYlzuWHojV7ru6P5+ck6GCwXRSv+xtF/5htJuBgPuQIVR1tV9MCW8AEF2wcTOL7Y3d+oyTHqBg/A==",
+      "dependencies": {
+        "@novel-segment/loader-line": "^1.0.31",
+        "@novel-segment/table-core-abstract": "^1.0.16",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/@novel-segment/table-stopword": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-stopword/-/table-stopword-1.0.13.tgz",
+      "integrity": "sha512-vxSa1P31cGXw4jJdTWvS+/dVwfPAR7e0t3KsIekkyixfo/4FMfINFhg0DbCJ0GaQ0h+yHZbp60dj6jerA7btAg==",
+      "dependencies": {
+        "@novel-segment/table-line": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-synonym": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-synonym/-/table-synonym-1.0.13.tgz",
+      "integrity": "sha512-WIO/XY/mhhLRUUyIZSvp2LG2U6NQWm/0VsHpTUKtV08d+Nyf5A2KtHOP8JefsNW8TDZPep5pQi3lA8sJPgJBSg==",
+      "dependencies": {
+        "@novel-segment/table-synonym-pangu": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/table-synonym-pangu": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-synonym-pangu/-/table-synonym-pangu-1.0.16.tgz",
+      "integrity": "sha512-aR/99s9K9r6tK91jPogl9ccULBTrgsxcuwPZTH0ViMViq3KHYboZa+SnmFP1MIjqcAwOUJDW/jP2wGC0qdhivg==",
+      "dependencies": {
+        "@novel-segment/table-core-abstract": "^1.0.16"
+      }
+    },
+    "node_modules/@novel-segment/types": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@novel-segment/types/-/types-1.0.11.tgz",
+      "integrity": "sha512-C2/xo0pONcetO7x759uuq2YfhkaUVZRuxvMnZxEL7FwJXnmdrw3xztjFlYeaDSuZWJTmrfOnv7jgWTLkI+iDTA=="
+    },
+    "node_modules/@novel-segment/util": {
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/@novel-segment/util/-/util-1.0.73.tgz",
+      "integrity": "sha512-NiRMOc7ncN4GOYPCySDe3HK4MFRCqXrbSQ0ImQ9k421NO3W7QMfwS54xR6bimK5aWuXerJwqEI+nVe7awUor1g==",
+      "dependencies": {
+        "@bluelovers/string-natural-compare": "^2.0.11",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2"
+      },
+      "peerDependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "cjk-conv": "*",
+        "str-util": "*",
+        "uni-string": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
+      "dependencies": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      },
+      "bin": {
+        "adler32": "bin/adler32.njs"
+      },
       "engines": {
         "node": ">=0.8"
       }
     },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": {
-        "debug": "4"
-      },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/array-hyper-unique": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/array-hyper-unique/-/array-hyper-unique-2.1.4.tgz",
+      "integrity": "sha512-RVsGx2YpFGhGpgdkK7A0VjFQecVUCowpkQerGCsyXVRXHxccAlPPTDt9ueF/X7Zq/6z6duZ49i9WzTCzcnQygQ==",
+      "dependencies": {
+        "deep-eql": "= 4.0.0",
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/async": {
@@ -677,6 +546,18 @@
         "lodash": "^4.17.14"
       }
     },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
@@ -685,10 +566,26 @@
         "node": "*"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/cfb": {
       "version": "1.2.2",
@@ -702,13 +599,74 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
+    "node_modules/cfb/node_modules/adler-32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/chinese-parseint2": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/chinese-parseint2/-/chinese-parseint2-2.0.6.tgz",
+      "integrity": "sha512-OZNUZHJ29I4HLj1sz2m41vO2gk1xxZridWc3YW2FB6y7Mda6Si3fpPzcAFA5vst0ZQBDbBxIJxioK/FV7zrp/A=="
+    },
+    "node_modules/cjk-conv": {
+      "version": "1.2.143",
+      "resolved": "https://registry.npmjs.org/cjk-conv/-/cjk-conv-1.2.143.tgz",
+      "integrity": "sha512-6t2yH0AzthiKniIjMW2VVuld7APYiGfyMnkWDPacSwzR1t7EWKNpnqwrOQz4iGp90++O10DKL8pULcn1trqlcg==",
+      "dependencies": {
+        "@lazy-cjk/jp-table-alias": "^1.0.41",
+        "@lazy-cjk/jp-table-comparison": "^1.0.29",
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/jp-table-voice": "^1.0.37",
+        "@lazy-cjk/novel-filename": "^1.0.50",
+        "@lazy-cjk/util": "^1.0.18",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "@lazy-cjk/zh-convert-table": "^1.0.23",
+        "@lazy-cjk/zh-slugify": "^1.0.86",
+        "@lazy-cjk/zh-table-alias": "^1.0.62",
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/class-proxy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/class-proxy/-/class-proxy-2.0.0.tgz",
+      "integrity": "sha512-BDQfDF/EThTivmMgaEpiwToj20nDzpXoverANmY7aJyTe2z4ss8ZRlFnWFkJqcMli9HvNDzO1+getFeoED/xZg=="
+    },
+    "node_modules/codepage": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha512-iz3zJLhlrg37/gYRWgEPkaFTtzmnEv1h+r7NgZum2lFElYQPi0/5bnmuDfODHxfp0INEfnRqyfyeIJDbb7ahRw==",
+      "dependencies": {
+        "commander": "~2.14.1",
+        "exit-on-epipe": "~1.0.1"
+      },
+      "bin": {
+        "codepage": "bin/codepage.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/codepage/node_modules/commander": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+      "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+    },
+    "node_modules/commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
+    "node_modules/core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA=="
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -721,20 +679,47 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "node_modules/crlf-normalize": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/crlf-normalize/-/crlf-normalize-1.0.19.tgz",
+      "integrity": "sha512-cpV1h7YwFtIA36NHtyWuMMMPGxUp6zrzxjRnFEDLh1ZH0SPNUqCWmM8RlKVycxvKHgZOxWXs3XxX/DAlBAjFzA==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ts-type": ">=2"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.0.0.tgz",
+      "integrity": "sha512-GxJC5MOg2KyQlv6WiUF/VAnMj4MWnYiXo4oLgeptOELVoknyErb4Z8+5F/IM/K4g9/80YzzatxmWcyRwUseH0A==",
+      "dependencies": {
+        "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deepmerge-plus": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/deepmerge-plus/-/deepmerge-plus-2.1.3.tgz",
+      "integrity": "sha512-nmRWdc9y7aqrhnZ1bWA+LOQuMV9WY6roWrZ7HN86l+JQ4HYRKXSQwOTNHseU88Py/knsov4j5Qh5RuFqCsNN8g==",
+      "dependencies": {
+        "is-mergeable-object": "1.1.0"
       },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/doublearray": {
@@ -742,21 +727,35 @@
       "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
       "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw=="
     },
+    "node_modules/emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
+    },
+    "node_modules/es6-class-prototype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es6-class-prototype/-/es6-class-prototype-2.0.0.tgz",
+      "integrity": "sha512-nn4YicqIBGRYIf8n/k45/iMfEZY8VVEW3jSeKWE9UTojR2evH1nl5fsJ9Cu7ZYZGUWaqZbXDyXMHk+e8ekw7Aw==",
+      "dependencies": {
+        "class-proxy": "^2.0.0"
+      }
+    },
     "node_modules/escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dependencies": {
         "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
         "esgenerate": "bin/esgenerate.js"
       },
       "engines": {
-        "node": ">=6.0"
+        "node": ">=4.0"
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
@@ -775,9 +774,9 @@
       }
     },
     "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "engines": {
         "node": ">=4.0"
       }
@@ -790,6 +789,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
@@ -798,35 +844,21 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "dependencies": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/idb-keyval": {
       "version": "6.2.1",
@@ -837,6 +869,46 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-mergeable-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.0.tgz",
+      "integrity": "sha512-JfyDDwUdtS4yHCgUpxOyKB9dnfZ0gecufxB0eytX6BmSXSE+8dbxDGt+V7CNRIRJ9sYFV/WQt2KJG6hNob2sBw=="
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/is-url": {
       "version": "1.2.4",
@@ -876,15 +948,77 @@
         "zlibjs": "^0.3.1"
       }
     },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "node_modules/lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A=="
+    },
+    "node_modules/lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ=="
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "node_modules/lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha512-SY0SwuPOHRwKcCNTdsntPYb+Zddz5mDUIVFABzRMqmAiL41pMeyoQFGxYAw5zdc9NnH4pbJqiqqp5ckfxa+zSA=="
+    },
+    "node_modules/lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha512-lsD+k73XztDsMBKPKvzHXRKFNMohTjoTKIIo4ADLn5dA65LZ1BqlAvSXhR2rPEC3BgAUQnzMnorqDtqn2z4IHA=="
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.12",
@@ -906,25 +1040,47 @@
       }
     },
     "node_modules/node-nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-4.27.0.tgz",
-      "integrity": "sha512-LnkhOUPXX0CMFbSzJ1gHI+7Yb3ULLip5gRsqedXb6pryjcRCbNzPgHXcH/6G9B1vSbDfO+y3X2B4QZpfP12OyQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-3.10.2.tgz",
+      "integrity": "sha512-xvTGtbNJNeCNX4zmhDhmyLoocRoEYPRiYBitiD6zptvUjzK9gpO3VXl08QNpKJQXNXvdUE50AecRTaDVM0i8DQ==",
       "dependencies": {
-        "@nlpjs/builtin-duckling": "^4.26.1",
-        "@nlpjs/builtin-microsoft": "^4.26.1",
-        "@nlpjs/core-loader": "^4.26.1",
-        "@nlpjs/emoji": "^4.26.1",
-        "@nlpjs/evaluator": "^4.26.1",
-        "@nlpjs/lang-all": "^4.26.1",
-        "@nlpjs/language": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlp": "^4.27.0",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/request": "^4.25.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/similarity": "^4.26.1",
-        "@nlpjs/xtables": "^4.25.0"
+        "@microsoft/recognizers-text-suite": "1.1.4",
+        "escodegen": "^1.12.0",
+        "esprima": "^4.0.1",
+        "kuromoji": "^0.1.2",
+        "novel-segment": "^2.5.0",
+        "xlsx": "^0.15.1"
+      }
+    },
+    "node_modules/novel-segment": {
+      "version": "2.7.108",
+      "resolved": "https://registry.npmjs.org/novel-segment/-/novel-segment-2.7.108.tgz",
+      "integrity": "sha512-O1WEuAhOr8KotCgX+wAuZkXlxFg/xJXhhtxVD2GhjJ7KnunCm4u2CmjbRhcuc3ABC9as/PAWTasKm7KkNT1Kyw==",
+      "dependencies": {
+        "@bluelovers/fast-glob": "^3.0.4",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "@novel-segment/postag": "^1.0.26",
+        "@novel-segment/stringify": "^1.0.14",
+        "@novel-segment/table-blacklist": "^1.0.13",
+        "@novel-segment/table-core-abstract": "^1.0.16",
+        "@novel-segment/table-dict": "^1.0.16",
+        "@novel-segment/table-stopword": "^1.0.13",
+        "@novel-segment/table-synonym": "^1.0.13",
+        "@novel-segment/types": "^1.0.11",
+        "array-hyper-unique": "^2.1.4",
+        "bluebird": "^3.7.2",
+        "cjk-conv": "^1.2.143",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "deepmerge-plus": "^2.1.3",
+        "regexp-cjk": "^3.3.110",
+        "segment-dict": "^2.3.194",
+        "sort-object-keys2": "^3.0.5",
+        "str-util": "^2.3.39",
+        "ts-enum-util": "4.0.2",
+        "ts-type": "^3.0.1",
+        "tslib": ">=2",
+        "uni-string": "^2.0.5"
       }
     },
     "node_modules/opencollective-postinstall": {
@@ -935,10 +1091,223 @@
         "opencollective-postinstall": "index.js"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==",
+      "bin": {
+        "printj": "bin/printj.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/regexp-cjk": {
+      "version": "3.3.110",
+      "resolved": "https://registry.npmjs.org/regexp-cjk/-/regexp-cjk-3.3.110.tgz",
+      "integrity": "sha512-j8xVAGrxtah6YsFOaNqg9E+XhBwblzuvqDLdIHx2j5+cwJwhWAT06sd+zt4Eht3bmrGkJskffSUtEgnXPn8lnQ==",
+      "dependencies": {
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "array-hyper-unique": "^2.1.4",
+        "lodash": "^4.17.21",
+        "regexp-helper": "^1.0.37",
+        "regexp-parser-event": "^1.1.43",
+        "regexp-parser-literal": "^1.1.36",
+        "regexp-range": "^2.0.3",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexp-helper": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/regexp-helper/-/regexp-helper-1.0.37.tgz",
+      "integrity": "sha512-ljaT9d0l9tbvAnfQad9LajUOBYOJv6dG4ERN523rzoHHtqYsTDKpUX5TrMzzR4VYB/hUKO9nrF8x8EtOyJssoA==",
+      "dependencies": {
+        "regexp-helper-core": "^2.0.7",
+        "regexp-support": "^1.0.52",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexp-helper-core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/regexp-helper-core/-/regexp-helper-core-2.0.7.tgz",
+      "integrity": "sha512-Os9hhbLSriww8+83t5JQ/ZD2kSTXliPQ0OZ5zY4OYIrNiGI9gl2mBfGW7yoLdhFobN8V8UqI4GgM5LgpaiRNjQ=="
+    },
+    "node_modules/regexp-parser-event": {
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/regexp-parser-event/-/regexp-parser-event-1.1.43.tgz",
+      "integrity": "sha512-yGNjt4JLfhjjW4ApnPMgCSzfWjPEFORm9m8ePjMg1LaxU194e3Jd698wqE6xgIo7A/HrrlBIELJaYK0tNugxQg==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "regexp-parser-literal": "^1.1.36",
+        "regexpp2": "^1.3.32",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexp-parser-literal": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/regexp-parser-literal/-/regexp-parser-literal-1.1.36.tgz",
+      "integrity": "sha512-voha1jKjL9fpoX+YT/5SSTT5MqZR+X909WTA5umRdBLO1ifU2K0uJYA1EcWAh4PL2wMDH8b8Fv2Iq/Znh/eVtw==",
+      "dependencies": {
+        "array-hyper-unique": "^2.1.4",
+        "emoji-regex": "^10.2.1",
+        "regexpp2": "^1.3.32",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "node_modules/regexp-range": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/regexp-range/-/regexp-range-2.0.3.tgz",
+      "integrity": "sha512-DdhZLQrwdEvOUSrJ6dttQYkZUr3ePn/AVacMgGpe9vRUDwGokgd5PtjryzY+DetZmo488JnEZQRWJDgKObKwMg==",
+      "dependencies": {
+        "@bluelovers/fill-range": "^7.0.2",
+        "@lazy-cjk/regexp-range-table": "^1.0.4",
+        "array-hyper-unique": "^2.1.4"
+      }
+    },
+    "node_modules/regexp-support": {
+      "version": "1.0.52",
+      "resolved": "https://registry.npmjs.org/regexp-support/-/regexp-support-1.0.52.tgz",
+      "integrity": "sha512-xrQ04NSjNZuUycj60MavZm3johOZSpob/lOKdu2lPPM/NPXeGxqN70bl8VmlkL16Bltf760ACPGBxbpD0SE+2g==",
+      "dependencies": {
+        "sort-object-keys2": "^3.0.4",
+        "tslib": ">=2"
+      }
+    },
+    "node_modules/regexpp2": {
+      "version": "1.3.32",
+      "resolved": "https://registry.npmjs.org/regexpp2/-/regexpp2-1.3.32.tgz",
+      "integrity": "sha512-vVwdpd23k3459hqLaEB2JeKhGM7fuuqVhWzT9ltdEXLC00yf7jcWltJxl0nM0tj2pLre90kXzJT6NvWdbc/6AA==",
+      "dependencies": {
+        "tslib": ">=2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/runes2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/runes2/-/runes2-1.1.2.tgz",
+      "integrity": "sha512-v6XIdRpUKdFLNhgF2AC9XvntZsDzxyTpVlpQ8HD592XD6vHiW8jEcHFnTV5ztUjWJC5cGOcdi9YKIwxWVh0f9w=="
+    },
+    "node_modules/segment-dict": {
+      "version": "2.3.194",
+      "resolved": "https://registry.npmjs.org/segment-dict/-/segment-dict-2.3.194.tgz",
+      "integrity": "sha512-/Pj6Z8mMm4oyzmxseRX58kt7AXOlhSjTp9A8uynnPiejJu7dsXizOi7igHlTWbA7ZDS0VWgKj2n8nv078RtZlQ==",
+      "dependencies": {
+        "@bluelovers/fast-glob": "^3.0.4",
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "@novel-segment/loader-stopword": "^1.0.28",
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/stream-loader-core": "^1.0.24",
+        "@novel-segment/util": "^1.0.73",
+        "bluebird": "^3.7.2",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "tslib": ">=2"
+      },
+      "peerDependencies": {
+        "novel-segment": "^2.7.103"
+      }
+    },
+    "node_modules/sort-object-keys2": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/sort-object-keys2/-/sort-object-keys2-3.0.5.tgz",
+      "integrity": "sha512-Q5fNSFbM4xXeTp1OtH62o67j+gzr2jPhZE0ES9bspDS26ScYfc2z5fL2vyRfVs947pkXCTS95Z/73lcbXuSJfg==",
+      "dependencies": {
+        "@lazy-array/util-unique": "^1.0.4"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -949,15 +1318,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.3.tgz",
+      "integrity": "sha512-pRuUdW0WwyB2doSqqjWyzwCD6PkfxpHAHdZp39K3dp/Hq7f+xfMwNAWIi16DyrRg4gg9c/RvLYkJTSawTPTm1w==",
       "dependencies": {
         "frac": "~1.1.2"
       },
+      "bin": {
+        "ssf": "bin/ssf.njs"
+      },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/str-util": {
+      "version": "2.3.40",
+      "resolved": "https://registry.npmjs.org/str-util/-/str-util-2.3.40.tgz",
+      "integrity": "sha512-wbrS5y0PAh+HtO7/3AESP6wfszS1QcBymTqjg1NwnA8W5NbqznwAt7l7rmpBHOupiVHmT8XWtR7skU3Qeqk3aQ==",
+      "dependencies": {
+        "@lazy-cjk/japanese": "^1.2.33",
+        "chinese-parseint2": "^2.0.6",
+        "cjk-conv": ">=1",
+        "deepmerge": "^4.3.1",
+        "is-fullwidth-code-point": "<4 >=3",
+        "strip-ansi": "<7 >=6",
+        "tslib": "^2",
+        "uni-string": "^2.0.5"
+      }
+    },
+    "node_modules/stream-pipe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-pipe/-/stream-pipe-1.0.4.tgz",
+      "integrity": "sha512-B60m1SSbH4yc7CTRj46hIu7/iDboTdurqEpXgzMxZMClTl2VCegn1lMr7OK0MTnRR3ziFpr7z5t15xUP31cqlw==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/string-natural-compare2": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-natural-compare2/-/string-natural-compare2-3.0.1.tgz",
+      "integrity": "sha512-2g5OCprlirAeevzB1hmxas7fFhXQpAH12uJrU7/+DSSk+KRw6hO9h+XW5CwFjnzxa0FRNYvrGtb0WvXDjEME5g=="
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tesseract.js": {
@@ -988,10 +1407,83 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/ts-enum-util": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ts-enum-util/-/ts-enum-util-4.0.2.tgz",
+      "integrity": "sha512-BB5qjvHYgYgOB/CaoA1Cy/B2QNnZ+nVBrJ15VV/AXGWx+AO83k5wgeLOJvkSLoKKavvH/M8Wj4ZbgROjsuYwzw=="
+    },
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "peer": true
+    },
+    "node_modules/ts-type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-3.0.1.tgz",
+      "integrity": "sha512-cleRydCkBGBFQ4KAvLH0ARIkciduS745prkGVVxPGvcRGhMMoSJUB7gNR1ByKhFTEYrYRg2CsMRGYnqp+6op+g==",
+      "dependencies": {
+        "@types/node": "*",
+        "tslib": ">=2",
+        "typedarray-dts": "^1.0.0"
+      },
+      "peerDependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA=="
+    },
+    "node_modules/uni-string": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uni-string/-/uni-string-2.0.5.tgz",
+      "integrity": "sha512-P2trBOQaqy9hiBtfkpn0MxripLhQqGua1Qy9cshYlVRIChUP6SmFhILWAsRWPhsWhGAWC8ymVYXr+vOKkyWALg==",
+      "dependencies": {
+        "es6-class-prototype": "^2.0.0",
+        "runes2": "^1.1.2"
+      }
     },
     "node_modules/wasm-feature-detect": {
       "version": "1.5.1",
@@ -1020,26 +1512,27 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "engines": {
-        "node": ">=0.8"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.15.6.tgz",
+      "integrity": "sha512-7vD9eutyLs65iDjNFimVN+gk/oDkfkCgpQUjdE82QgzJCrBHC4bGPH7fzKVyy0UPp3gyFVQTQEFJaWaAvZCShQ==",
       "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.14.0",
+        "commander": "~2.17.1",
+        "crc-32": "~1.2.0",
+        "exit-on-epipe": "~1.0.1",
+        "ssf": "~0.10.3",
+        "wmf": "~1.0.1"
       },
       "bin": {
         "xlsx": "bin/xlsx.njs"
@@ -1058,44 +1551,233 @@
     }
   },
   "dependencies": {
+    "@bluelovers/fast-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@bluelovers/fast-glob/-/fast-glob-3.0.4.tgz",
+      "integrity": "sha512-djAOOjDWXolYArm5NXxOIX7Q7OGhAaRtMs5F968OxelWkMUU6PyU6tS66CFykVON4U5y8jXcsnVAFCaeuf1nEA==",
+      "requires": {
+        "bluebird": "^3",
+        "fast-glob": "^3"
+      }
+    },
+    "@bluelovers/fill-range": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@bluelovers/fill-range/-/fill-range-7.0.2.tgz",
+      "integrity": "sha512-KBuuuw6L/FoRUEhgpwM3z5wJ2Zo4ociL5hb7D/B4LDhe5U0Z3CL53i1+c1fcUXx1wExLyA77wtvzK5j+qEigyw==",
+      "requires": {
+        "@bluelovers/to-regex-range2": "^5.0.1"
+      }
+    },
+    "@bluelovers/string-natural-compare": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@bluelovers/string-natural-compare/-/string-natural-compare-2.0.11.tgz",
+      "integrity": "sha512-k2KanWgqg6scH37zI7xd/5jFdFWg+V6Z9P1sl3RxrA855AFLbcFeAJMGMN8Dop547MUh5Tq3KKVttvE8DY5yUA==",
+      "requires": {
+        "string-natural-compare2": "^3.0.1"
+      }
+    },
+    "@bluelovers/to-regex-range2": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@bluelovers/to-regex-range2/-/to-regex-range2-5.0.1.tgz",
+      "integrity": "sha512-0fVn7EqIBAZjlnyzz87E5JUs0H+4KwW/i2RVzWRbcjb+xBxD0TIvRGUYGrfvb5eiQf0cuJn4F/zkTmd0cgrA0g==",
+      "requires": {
+        "@lazy-assert/check-basic": "^1.0.8"
+      }
+    },
+    "@lazy-array/util-unique": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lazy-array/util-unique/-/util-unique-1.0.4.tgz",
+      "integrity": "sha512-zSffxqZZ8VhO068JG+HlYaUJC5ciCdyJnuUYysntTObrwLsA5bS+A09vhSVZ/On8ft+bOMYoAhAZOTw9Y0q70g=="
+    },
+    "@lazy-assert/check-basic": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@lazy-assert/check-basic/-/check-basic-1.0.12.tgz",
+      "integrity": "sha512-Zttg9K7CBNcNlGDM+AQ9rqschYJ0c8tvJ/35iBuiqefZ9RuaW9C1Ww0AGgp9MVLL/h1/uBbY6CDuz+VRzCDDAg=="
+    },
+    "@lazy-cjk/japanese": {
+      "version": "1.2.33",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/japanese/-/japanese-1.2.33.tgz",
+      "integrity": "sha512-n5M/eL6QQd1i/JH3cZ4L2Z3WkeNOXfIUlLt21Zvi4o1YGpth2Nf4OLVuPp/SwYYOpFfaN6JT9YkJ49ZOuIAKgA==",
+      "requires": {
+        "big.js": "^6.2.1",
+        "lodash": "^4.17.21",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/jp-table-alias": {
+      "version": "1.0.41",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-alias/-/jp-table-alias-1.0.41.tgz",
+      "integrity": "sha512-Sv0vw0JhJqtYEhF5HgQVQ+eSRSejFCUdcHEafstaMCQ3juVaVSfe6b4LOj339+rucUEduBznnMy6LqXMp7MJ7A==",
+      "requires": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/jp-table-comparison": {
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-comparison/-/jp-table-comparison-1.0.29.tgz",
+      "integrity": "sha512-yy+KrAk9ORhjJHB3VOWiQ/Wrx+CGP2PwCjixqRuw7xU1v2p8QRSiDAcPvh1FX+ObD/fenRq09NMEAw3X8pJlJg==",
+      "requires": {
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/jp-table-convert": {
+      "version": "1.0.46",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-convert/-/jp-table-convert-1.0.46.tgz",
+      "integrity": "sha512-VhOGMBm1WGh0rUNCwJmVKPIuXVV5KcOqvynrwZUm7HJ6zsccNDPR7PsxFX0L5uS0xC7JdKgjlr2WrmgzY5lXGA==",
+      "requires": {
+        "@lazy-cjk/jp-table-comparison": "^1.0.29",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "@lazy-cjk/jp-table-voice": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/jp-table-voice/-/jp-table-voice-1.0.37.tgz",
+      "integrity": "sha512-v1fnb1gBsjJ6fm2dQdFflH9gfQimg8tD6MoIpqlgaAiOTMtLina+MnmFoIw39WZp1ARiHAXqvO4Z6DgZRmp+2g==",
+      "requires": {
+        "array-hyper-unique": "^2.1.4",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/novel-filename": {
+      "version": "1.0.50",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/novel-filename/-/novel-filename-1.0.50.tgz",
+      "integrity": "sha512-msjq8cXWGz8VZVGW5TR5+1MfH6RN73NZzPmv6yfzAZ04TJsQqAy0qvkRfl9oGYfxdIoly7tzq0TSf81VKh40Xg==",
+      "requires": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/regexp-range-table": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/regexp-range-table/-/regexp-range-table-1.0.4.tgz",
+      "integrity": "sha512-Awt1XSFQQjxEgHORhJPkMfbPpxs2cvQXDFXqpK0fXYy3OyhJDUzZMS8wEWhf208kbbMefEWmVtbC2T2E+GagvQ=="
+    },
+    "@lazy-cjk/static-build-zh-convert": {
+      "version": "1.0.51",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/static-build-zh-convert/-/static-build-zh-convert-1.0.51.tgz",
+      "integrity": "sha512-COEoNSL/wX08D2Epf8sItnSMFA9t2/imYJM5N+sglLY0sWaWM9T/bNcBAQTpLggslmylUX/IOZ14XxbJjkmzPg==",
+      "requires": {
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/util": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/util/-/util-1.0.18.tgz",
+      "integrity": "sha512-5Hxm60wBaulhBQmOeAOdvNky/BRTckeo/nZFS/SwOr9mPdczn6NHn4Nqbk4XMqZCvBbOBFnren85MKo5y/UsbQ==",
+      "requires": {
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "@lazy-cjk/zh-convert": {
+      "version": "1.0.48",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-convert/-/zh-convert-1.0.48.tgz",
+      "integrity": "sha512-yRf5K24JAtpysXYloI4FhLmzcdbDleR5T25/H7QHoz+Qx+lj86/Bf1Ta9mLnElv9liFgE0RWGEeppKs5rZqQzA==",
+      "requires": {
+        "@lazy-cjk/static-build-zh-convert": "^1.0.51",
+        "array-hyper-unique": "^2.1.4",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "@lazy-cjk/zh-convert-table": {
+      "version": "1.0.23",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-convert-table/-/zh-convert-table-1.0.23.tgz",
+      "integrity": "sha512-73kuMrTkwSEWeFI0ZI57JdIDBieh+yXk6s1A9NMBf1tgGnV2DR8c+BMVTalVDbhx8Skyh69iXawdP7/aeElfyw==",
+      "requires": {
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/zh-slugify": {
+      "version": "1.0.86",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-slugify/-/zh-slugify-1.0.86.tgz",
+      "integrity": "sha512-P/xjZTsQYfCIv9qH6hlLvkuYxI3tpDVT9gPQ52+NkJrQyORZiJub+z4mmqBHf/ZXgo/+ZVeKzo8UCp6YT0LCUQ==",
+      "requires": {
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/zh-table-alias": {
+      "version": "1.0.62",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-alias/-/zh-table-alias-1.0.62.tgz",
+      "integrity": "sha512-ppNQ4VGP+zaBGUGvXPeLANc8zy6Yi9r3pzVySB+ypy+n3C43QOpJJoWtIvEuKfmFGju4ZKO6CucCwEnf9U3mwQ==",
+      "requires": {
+        "@lazy-cjk/jp-table-alias": "^1.0.41",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "array-hyper-unique": "^2.1.4",
+        "deepmerge-plus": "^2.1.3",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "@lazy-cjk/zh-table-greedy": {
+      "version": "1.0.90",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-greedy/-/zh-table-greedy-1.0.90.tgz",
+      "integrity": "sha512-ktk6dH9yuGPJEmEZtliYCNALbKO6jfmXjSFabnF1hgNW/uk2rg5r5nydyFXa4rECclSbk88xT0sXe2cBTOf30A==",
+      "requires": {
+        "array-hyper-unique": "^2.1.4",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "@lazy-cjk/zh-table-list": {
+      "version": "1.0.84",
+      "resolved": "https://registry.npmjs.org/@lazy-cjk/zh-table-list/-/zh-table-list-1.0.84.tgz",
+      "integrity": "sha512-xzzQf2rDSmovYT98gHTN2LXGITsy1NNIbu6Klp2zC2Tk0SjeUcRhMxJjVWQUtXBbBQ3UlSZKrTvutpRFjVja0g==",
+      "requires": {
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "@lazy-cjk/zh-table-alias": "^1.0.62",
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
     "@microsoft/recognizers-text": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.3.1.tgz",
-      "integrity": "sha512-HikLoRUgSzM4OKP3JVBzUUp3Q7L4wgI17p/3rERF01HVmopcujY3i6wgx8PenCwbenyTNxjr1AwSDSVuFlYedQ=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text/-/recognizers-text-1.1.4.tgz",
+      "integrity": "sha512-hlSVXcaX5i8JcjuUJpVxmy2Z/GxvFXarF0KVySCFop57wNEnrLWMHe4I4DjP866G19VyIKRw+vPA32pkGhZgTg=="
     },
     "@microsoft/recognizers-text-choice": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.3.1.tgz",
-      "integrity": "sha512-HubunMJVq/OetmdvcAmBh5skMlg+yiScm3V2wNyNZIVvLgli4+8nzbg/W/fI9dpaf6wv9ZQ7d2IYvn8swJBo3A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-choice/-/recognizers-text-choice-1.1.4.tgz",
+      "integrity": "sha512-4CddwFe4RVhZeJgW65ocBrEdeukBMghK8pgI0K0Qy2eA5ysPZQpeZ7BGSDz5QMQei5LPY+QaAQ3CHU+ORHoO7A==",
       "requires": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "grapheme-splitter": "^1.0.2"
       }
     },
-    "@microsoft/recognizers-text-data-types-timex-expression": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-data-types-timex-expression/-/recognizers-text-data-types-timex-expression-1.3.1.tgz",
-      "integrity": "sha512-jarJIFIJZBqeofy3hh0vdQo1yOmTM+jCjj6/zmo9JunsQ6LO750eZHCg9eLptQhsvq321XCt5xdRNLCwU8YeNA=="
-    },
     "@microsoft/recognizers-text-date-time": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.3.2.tgz",
-      "integrity": "sha512-fUEGOTccS55ZY0erzjS1bunJYA9lGXjcZoru5oPOlnxbJS4Lk0ylgdH2Ub2EjAyqr8DIJhdLNOEesCdAXMvlNg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-date-time/-/recognizers-text-date-time-1.1.4.tgz",
+      "integrity": "sha512-leMnjN+KYNwNvRD5T4G0ORUzkjlek/BBZDvQIjAujtyrd/pkViUnuouWIPkFT/dbSOxXML8et54CSk2KfHiWIA==",
       "requires": {
-        "@microsoft/recognizers-text": "~1.3.1",
-        "@microsoft/recognizers-text-number": "~1.3.1",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.1",
-        "lodash": "^4.17.21"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "lodash.isequal": "^4.5.0",
+        "lodash.tonumber": "^4.0.3"
       }
     },
     "@microsoft/recognizers-text-number": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.3.1.tgz",
-      "integrity": "sha512-JBxhSdihdQLQilCtqISEBw5kM+CNGTXzy5j5hNoZECNUEvBUPkAGNEJAeQPMP5abrYks29aSklnSvSyLObXaNQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number/-/recognizers-text-number-1.1.4.tgz",
+      "integrity": "sha512-6EmlR+HR+eJBIX7sQby1vs6LJB64wxLowHaGpIU9OCXFvZ5Nb0QT8qh10rC40v3Mtrz4DpScXfSXr9tWkIO5MQ==",
       "requires": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "bignumber.js": "^7.2.1",
-        "lodash": "^4.17.21"
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.sortby": "^4.7.0",
+        "lodash.trimend": "^4.5.1"
       },
       "dependencies": {
         "bignumber.js": {
@@ -1106,576 +1788,238 @@
       }
     },
     "@microsoft/recognizers-text-number-with-unit": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.3.1.tgz",
-      "integrity": "sha512-gzCpPP4zQ5Vb+RHaWjzP2t1c+mj6GYOsFoI2NyJkm8OZ52XI+x9SJCgrrD2ujzjOd5/CQVC46rE22rfGwXLDkA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-number-with-unit/-/recognizers-text-number-with-unit-1.1.4.tgz",
+      "integrity": "sha512-zl+CfmfWK0x/x+iSgaBAevKTYO0F4+z7SYHAHztaaaGuX8FERw2jmUjSgVetm5KA3EveyCx0XYGU1mRNY8p7Eg==",
       "requires": {
-        "@microsoft/recognizers-text": "~1.3.1",
-        "@microsoft/recognizers-text-number": "~1.3.1",
-        "lodash": "^4.17.21"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.last": "^3.0.0",
+        "lodash.max": "^4.0.1"
       }
     },
     "@microsoft/recognizers-text-sequence": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.3.1.tgz",
-      "integrity": "sha512-J7Kg35hpm0NcFHmu69Bb4q7DPDiSpCd8ApUZqNm59itIjrQJHpSdl9HF6JxuQQz0Ftc/li5ZLqSuupJAmA/sgg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-sequence/-/recognizers-text-sequence-1.1.4.tgz",
+      "integrity": "sha512-rb5j8/aE7HSOdIxaVfCGFrj0wWPpSq0CuykFg/A/iJNPP+FnAU71bgP5HexrwQcpCsDinauisX7u0DKIChrHRA==",
       "requires": {
-        "@microsoft/recognizers-text": "~1.3.1",
+        "@microsoft/recognizers-text": "~1.1.4",
         "grapheme-splitter": "^1.0.2"
       }
     },
     "@microsoft/recognizers-text-suite": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.3.0.tgz",
-      "integrity": "sha512-uqG4vzy5N2CmBaeINny0bLdnGp0jDbT1moNoLC+Yim3G8kHOU9lpDfwA6VN6HTYaDM5854SNMEzLjJdS1TPFTw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/recognizers-text-suite/-/recognizers-text-suite-1.1.4.tgz",
+      "integrity": "sha512-hNIaR4M2G0nNeI9WZxt9C0KYh/1vhjeKzX5Ds8XDdT0pxF7zwCSo19WNcPjrVK6aCOeZTw/ULofsAjdu9gSkcA==",
       "requires": {
-        "@microsoft/recognizers-text": "~1.3.0",
-        "@microsoft/recognizers-text-choice": "~1.3.0",
-        "@microsoft/recognizers-text-data-types-timex-expression": "~1.3.0",
-        "@microsoft/recognizers-text-date-time": "~1.3.0",
-        "@microsoft/recognizers-text-number": "~1.3.0",
-        "@microsoft/recognizers-text-number-with-unit": "~1.3.0",
-        "@microsoft/recognizers-text-sequence": "~1.3.0"
+        "@microsoft/recognizers-text": "~1.1.4",
+        "@microsoft/recognizers-text-choice": "~1.1.4",
+        "@microsoft/recognizers-text-date-time": "~1.1.4",
+        "@microsoft/recognizers-text-number": "~1.1.4",
+        "@microsoft/recognizers-text-number-with-unit": "~1.1.4",
+        "@microsoft/recognizers-text-sequence": "~1.1.4"
       }
     },
-    "@nlpjs/builtin-duckling": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-duckling/-/builtin-duckling-4.26.1.tgz",
-      "integrity": "sha512-3qkH955X2g5MXV1EqT3fTAT/lLEdiqqe5IgBDyr+MQB7FOV9R3YhqGIn3DFOl+TSm/tP5n/BAEptkTNn/TOpmQ==",
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
       }
     },
-    "@nlpjs/builtin-microsoft": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/builtin-microsoft/-/builtin-microsoft-4.26.1.tgz",
-      "integrity": "sha512-AODgzTcfYUf5Ozm00aQnHImDum7Idtl0F9dSPoaXpfj7rZqP8hPZ7iWwdGTAvISH/da2YhjPOU65QSYk2YpjFA==",
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "requires": {
-        "@microsoft/recognizers-text-suite": "1.3.0",
-        "@nlpjs/core": "^4.26.1"
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
       }
     },
-    "@nlpjs/core": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core/-/core-4.26.1.tgz",
-      "integrity": "sha512-M/PeFddsi3y7Z1piFJxsLGm5/xdMhcrpOsml7s6CTEgYo8iduaT30HDd61tZxDyvvJseU6uFqlXSn7XKkAcC1g=="
-    },
-    "@nlpjs/core-loader": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/core-loader/-/core-loader-4.26.1.tgz",
-      "integrity": "sha512-IiRtn65bdiUSQHy2kusco2fmhk39u2Mc2c5Fsm9+9EVG6BtJCmVEFU/btAzGDAmxEA/E4qKecaAT4LvcW6TPbA==",
+    "@novel-segment/dict-loader-core": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@novel-segment/dict-loader-core/-/dict-loader-core-1.0.28.tgz",
+      "integrity": "sha512-o7XQilS3uzjR8qxjqI7wh9zM3I0K68qPjsTj7OTK6VHSZThtO5CORRxTx18OYRonFvHGMuppd/4ad1WnsjjG0g==",
       "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/request": "^4.25.0"
+        "bluebird": "^3.7.2",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/emoji": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/emoji/-/emoji-4.26.1.tgz",
-      "integrity": "sha512-Q0PoXwIvaB1bnRXK4U/YD7mrqaz29Yfed3s2au0iXl1bffUgoG+hs4GORCvyy7DFCCLlc9d5yDM3oLIX/ggZ+Q==",
+    "@novel-segment/loader-line": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loader-line/-/loader-line-1.0.31.tgz",
+      "integrity": "sha512-iMvkC8oYiroBNyB4soyUj9hMLMeKM+Vz7g8hNvM2k/998BSo7R4ZReWBJ7LBWhaLSkRKfg7IH1UuHMtCTpdEng==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/evaluator": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/evaluator/-/evaluator-4.26.1.tgz",
-      "integrity": "sha512-WeUrC8qq7+V8Jhkkjc2yiXdzy9V0wbETv8/qasQmL0QmEuwBDJF+fvfl4z2vWpBb0vW07A8aNrFElKELzbpkdg==",
+    "@novel-segment/loader-stopword": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loader-stopword/-/loader-stopword-1.0.28.tgz",
+      "integrity": "sha512-UxHd3pC1v0J4GdXcCxXSvbCqXHptUKb6xBkSRzfSrnHJoFfMagn3oPduP2GYkQGJ6HqPceZZNmSjG5e/tyLEMQ==",
       "requires": {
-        "escodegen": "^2.0.0",
-        "esprima": "^4.0.1"
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/lang-all": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-all/-/lang-all-4.26.1.tgz",
-      "integrity": "sha512-UzRm1JRRAyQqilEOxQ2ySMOitKbhPk5iKYbjD8FREDcPjreUvDxVuQsYUOvYucmEyFcZU2U/TdJx+fX9/bcaKQ==",
+    "@novel-segment/loaders": {
+      "version": "1.0.47",
+      "resolved": "https://registry.npmjs.org/@novel-segment/loaders/-/loaders-1.0.47.tgz",
+      "integrity": "sha512-Akoal+sM6B6RaDhONRREclCowbEwNrJuyM0AKnK836VsykNECIcWoAvos6iBwQbEVZLYinCVH/gMjj+hxsWK1A==",
       "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-ar": "^4.26.1",
-        "@nlpjs/lang-bn": "^4.26.1",
-        "@nlpjs/lang-ca": "^4.26.1",
-        "@nlpjs/lang-cs": "^4.26.1",
-        "@nlpjs/lang-da": "^4.26.1",
-        "@nlpjs/lang-de": "^4.26.1",
-        "@nlpjs/lang-el": "^4.26.1",
-        "@nlpjs/lang-en": "^4.26.1",
-        "@nlpjs/lang-es": "^4.26.1",
-        "@nlpjs/lang-eu": "^4.26.1",
-        "@nlpjs/lang-fa": "^4.26.1",
-        "@nlpjs/lang-fi": "^4.26.1",
-        "@nlpjs/lang-fr": "^4.26.1",
-        "@nlpjs/lang-ga": "^4.26.1",
-        "@nlpjs/lang-gl": "^4.26.1",
-        "@nlpjs/lang-hi": "^4.26.1",
-        "@nlpjs/lang-hu": "^4.26.1",
-        "@nlpjs/lang-hy": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1",
-        "@nlpjs/lang-it": "^4.26.1",
-        "@nlpjs/lang-ja": "^4.26.1",
-        "@nlpjs/lang-ko": "^4.26.1",
-        "@nlpjs/lang-lt": "^4.26.1",
-        "@nlpjs/lang-ms": "^4.26.1",
-        "@nlpjs/lang-ne": "^4.26.1",
-        "@nlpjs/lang-nl": "^4.26.1",
-        "@nlpjs/lang-no": "^4.26.1",
-        "@nlpjs/lang-pl": "^4.26.1",
-        "@nlpjs/lang-pt": "^4.26.1",
-        "@nlpjs/lang-ro": "^4.26.1",
-        "@nlpjs/lang-ru": "^4.26.1",
-        "@nlpjs/lang-sl": "^4.26.1",
-        "@nlpjs/lang-sr": "^4.26.1",
-        "@nlpjs/lang-sv": "^4.26.1",
-        "@nlpjs/lang-ta": "^4.26.1",
-        "@nlpjs/lang-th": "^4.26.1",
-        "@nlpjs/lang-tl": "^4.26.1",
-        "@nlpjs/lang-tr": "^4.26.1",
-        "@nlpjs/lang-uk": "^4.26.1",
-        "@nlpjs/lang-zh": "^4.26.1",
-        "@nlpjs/language": "^4.25.0"
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "@novel-segment/loader-line": "^1.0.31",
+        "@novel-segment/loader-stopword": "^1.0.28",
+        "@novel-segment/stream-loader-core": "^1.0.24",
+        "@novel-segment/types": "^1.0.11",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/lang-ar": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ar/-/lang-ar-4.26.1.tgz",
-      "integrity": "sha512-MUlVtabt9ltG7WyzCQpFJymLJlnEqp3mxhgN9JHyFH7oZMK3REvMovFfvEUAbfiYrJEv/BN5KKLL7yrvUeaHtg==",
+    "@novel-segment/postag": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@novel-segment/postag/-/postag-1.0.26.tgz",
+      "integrity": "sha512-msd/oImyQQF3ghUfWZhNXnqk6puxV7w9OTY82olZt5zh2bgUpXpGU3JeTslcqLqbGKDCuu6HLSE4Hy2IFgEuow==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "ts-enum-util": "^4.0.2",
+        "ts-type": "^3.0.1",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/lang-bn": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-bn/-/lang-bn-4.26.1.tgz",
-      "integrity": "sha512-sim1iZKBDdehi/yBUKrLW51QvS9uB+sXW7lj+THVqBy5UsnEQvt4gzE0NsC873uJMh66vt2AlHkhzgPH0qH/nQ==",
+    "@novel-segment/stream-loader-core": {
+      "version": "1.0.24",
+      "resolved": "https://registry.npmjs.org/@novel-segment/stream-loader-core/-/stream-loader-core-1.0.24.tgz",
+      "integrity": "sha512-MnMt4jweAjkYxcLjn8jwtN83ckWoCftynOie0VIGAt+nPsgjyzkFmvp8tWG1PNMO8v2YZo0731b5e8O8qx+6HQ==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "bluebird": "^3.7.2",
+        "split2": "^4.2.0",
+        "stream-pipe": "^1.0.4",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/lang-ca": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ca/-/lang-ca-4.26.1.tgz",
-      "integrity": "sha512-fD4R5tcAB0uYtNxSEF20b1KmF6nUQSbiJqrIUJI5yis4ObjCYRQnSh4bjVDKUKxyONjbD6L8EaK5GrY1/jkwFQ==",
+    "@novel-segment/stringify": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@novel-segment/stringify/-/stringify-1.0.14.tgz",
+      "integrity": "sha512-RcQjTtVh3hHLUfd2hhxfhQio9j4bunHc9JkH6+Ip2bsP1XuBSf4mjtL01l7H7WemP8qF+YTz8z94lkxVrGowjg==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/types": "^1.0.11",
+        "ts-type": "^3.0.1"
       }
     },
-    "@nlpjs/lang-cs": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-cs/-/lang-cs-4.26.1.tgz",
-      "integrity": "sha512-CqI6VB8toaJ/MlP1D4K9BctA6GpZJhMKyEy+OX9xavDe4r4ao/SxlSaIYK3izK0k+J38lJWC5lXYGazfCdTGjA==",
+    "@novel-segment/table-blacklist": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-blacklist/-/table-blacklist-1.0.13.tgz",
+      "integrity": "sha512-P/lPDPMseujCOGy0IDxextRxRJiOWC+xqlaFHQTH8BE3RpimULmlE6YcUswBPwdRiBJNg0WVJ/KN+0n5x3FgGQ==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/table-line": "^1.0.16"
       }
     },
-    "@nlpjs/lang-da": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-da/-/lang-da-4.26.1.tgz",
-      "integrity": "sha512-krI/ojeDSi329ENM/hLIsbUh1x4XRTKAbtPcbFxAY6XVhcSVoWPO7L77jFTL1NQeE1oGRFzGHaeC9hZJ8phVbA==",
+    "@novel-segment/table-core-abstract": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-core-abstract/-/table-core-abstract-1.0.16.tgz",
+      "integrity": "sha512-NlKDtAmw4dQqCc2ndQWpiII0To/zm2we2VeOa5UsJx4KQT8Q36Ss8l+g3EYF0wrRFvIg53YivXsPy3MOkUsC8A==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/types": "^1.0.11",
+        "lodash": "^4.17.21",
+        "ts-type": "^3.0.1"
       }
     },
-    "@nlpjs/lang-de": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-de/-/lang-de-4.26.1.tgz",
-      "integrity": "sha512-HfZQwsE5FICq9taVZDiyktmdAePVF5948NM80et0d9mx43RWDFhHKQYgtJPwfQXtdCoQtOM5TOJ2FanGwzPeaA==",
+    "@novel-segment/table-dict": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-dict/-/table-dict-1.0.16.tgz",
+      "integrity": "sha512-YohOPI4v9X2PYF3eo2vkivOZeFaGzATlmoMbFAFBYwJgtjNgR8pTzuicIv1LTfba4xTBjkDbLZ8UNVwCFqmGhw==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/table-core-abstract": "^1.0.16"
       }
     },
-    "@nlpjs/lang-el": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-el/-/lang-el-4.26.1.tgz",
-      "integrity": "sha512-pcOvuSwPCXxI+2xNZZzM4V5pTRDntYoJi0SP/ic2nV4IPQ0nU2j16dYfg1HlvET/E6iN1VTqghrCaf10SMkDGA==",
+    "@novel-segment/table-line": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-line/-/table-line-1.0.16.tgz",
+      "integrity": "sha512-cb0W9slOkFDYlzuWHojV7ru6P5+ck6GCwXRSv+xtF/5htJuBgPuQIVR1tV9MCW8AEF2wcTOL7Y3d+oyTHqBg/A==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/loader-line": "^1.0.31",
+        "@novel-segment/table-core-abstract": "^1.0.16",
+        "lodash": "^4.17.21"
       }
     },
-    "@nlpjs/lang-en": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en/-/lang-en-4.26.1.tgz",
-      "integrity": "sha512-GVoJpOjyk5TtBAqo/fxsiuuH7jXycyakGT0gw5f01u9lOmUnpJegvXyGff/Nb0j14pXcGHXOhmpWrcTrG2B0LQ==",
+    "@novel-segment/table-stopword": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-stopword/-/table-stopword-1.0.13.tgz",
+      "integrity": "sha512-vxSa1P31cGXw4jJdTWvS+/dVwfPAR7e0t3KsIekkyixfo/4FMfINFhg0DbCJ0GaQ0h+yHZbp60dj6jerA7btAg==",
       "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-en-min": "^4.26.1"
+        "@novel-segment/table-line": "^1.0.16"
       }
     },
-    "@nlpjs/lang-en-min": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-en-min/-/lang-en-min-4.26.1.tgz",
-      "integrity": "sha512-1sJZ7dy7ysqzbsB8IklguvB88J8EPIv4XGVkZCcwecKtOw+fp5LAsZ3TJVmEf18iK1gD4cEGr7qZg5fpPxTpWQ==",
+    "@novel-segment/table-synonym": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-synonym/-/table-synonym-1.0.13.tgz",
+      "integrity": "sha512-WIO/XY/mhhLRUUyIZSvp2LG2U6NQWm/0VsHpTUKtV08d+Nyf5A2KtHOP8JefsNW8TDZPep5pQi3lA8sJPgJBSg==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/table-synonym-pangu": "^1.0.16"
       }
     },
-    "@nlpjs/lang-es": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-es/-/lang-es-4.26.1.tgz",
-      "integrity": "sha512-fIPQt+WPcNdyxZOCMkOPlMb4Y1iE585QxjB9IAdFz8ZtVg7mc4dlv5f46ud7ppdMh84iLOuOdo6pzu2Cqm14lw==",
+    "@novel-segment/table-synonym-pangu": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@novel-segment/table-synonym-pangu/-/table-synonym-pangu-1.0.16.tgz",
+      "integrity": "sha512-aR/99s9K9r6tK91jPogl9ccULBTrgsxcuwPZTH0ViMViq3KHYboZa+SnmFP1MIjqcAwOUJDW/jP2wGC0qdhivg==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@novel-segment/table-core-abstract": "^1.0.16"
       }
     },
-    "@nlpjs/lang-eu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-eu/-/lang-eu-4.26.1.tgz",
-      "integrity": "sha512-Ha8GHTbgQYd7dwHM8aWHDyxmbUNUcyu/5xlBKqqBOPxysDyZ6Ad0tvj0FmJBy6mYhqmFTPBnEAo69cfuFSqWIQ==",
+    "@novel-segment/types": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@novel-segment/types/-/types-1.0.11.tgz",
+      "integrity": "sha512-C2/xo0pONcetO7x759uuq2YfhkaUVZRuxvMnZxEL7FwJXnmdrw3xztjFlYeaDSuZWJTmrfOnv7jgWTLkI+iDTA=="
+    },
+    "@novel-segment/util": {
+      "version": "1.0.73",
+      "resolved": "https://registry.npmjs.org/@novel-segment/util/-/util-1.0.73.tgz",
+      "integrity": "sha512-NiRMOc7ncN4GOYPCySDe3HK4MFRCqXrbSQ0ImQ9k421NO3W7QMfwS54xR6bimK5aWuXerJwqEI+nVe7awUor1g==",
       "requires": {
-        "@nlpjs/core": "^4.26.1"
+        "@bluelovers/string-natural-compare": "^2.0.11",
+        "regexp-helper": "^1.0.37",
+        "tslib": ">=2"
       }
     },
-    "@nlpjs/lang-fa": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fa/-/lang-fa-4.26.1.tgz",
-      "integrity": "sha512-qJCmNXgJZnfNXUnKnxvEGEzSFBdQT4XU7/rMxuFmSJqmQY7fH/Vsmi5CKF94VRBPOIV4ULlEJuLpUWHXRmOnVQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-fi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fi/-/lang-fi-4.26.1.tgz",
-      "integrity": "sha512-W/rUcrzSh3KE07q2vOsssTpU1sbX32gbBzKPZfRJ2ZUF4afO+eHxmAywikXubP4kiU3JxVNLvXXEjuGD3SBUbA==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-fr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-fr/-/lang-fr-4.26.1.tgz",
-      "integrity": "sha512-LTA852atCJnHtKDmtjx/ui5AnvEIkrPx+MJQ2mB3gn8ko6i2UITnJgPmJE9Kej5bLasVZOAJvU/SrfXEmnPGOw==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ga": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ga/-/lang-ga-4.26.1.tgz",
-      "integrity": "sha512-JsP1CZ8r3Jd6o/Az7cN3exz0HDP3FNYLzh4Vi6ksEkdKF0yCjJ9G5dXZYqS9qFIN5ffemWn29G4WRELY6QH/cQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-gl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-gl/-/lang-gl-4.26.1.tgz",
-      "integrity": "sha512-y1NNu6NVy/6o5UNfihgg0WkSlVr4IvKA5W193CpRLZWS4FccQDmnFFhyYWRkshyDbgEsfsZ0Rs3BoE82+T2Ubg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-hi": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hi/-/lang-hi-4.26.1.tgz",
-      "integrity": "sha512-Fw9rXqF5l8q9etJG5uOlEFpnMVjQEWMaCIgQfEcA1yTvieSV8mpoSvQkEZl+DFhww+azareoJ7ZCkx0gJ9UDuQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-hu": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hu/-/lang-hu-4.26.1.tgz",
-      "integrity": "sha512-7dPUn5/ZpLZmsdRwO+dtORuMIiIpnsWbgSLIKdOLh8irhgUR+M2bYTfkdnKcrEcHzHPP8Svn7pU0xk7OKSUA1w==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-hy": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-hy/-/lang-hy-4.26.1.tgz",
-      "integrity": "sha512-T2brpLGDJryAwWmjtnmY8Ot6ZUkCz+/nRR9/QM1PybvZIqOVLjJqA49bqjJfT5DMN89HbwC7I/15NTT0y09i1Q==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-id": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-id/-/lang-id-4.26.1.tgz",
-      "integrity": "sha512-rVuIkYFKdltFhMT/a2ZxD9ovoZSVZF7OPuqYjTXW9xKd3Ff32yUrzcf/pHXlqmZOSltqOH3E5jZRRDkHvgUOjQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-it": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-it/-/lang-it-4.26.1.tgz",
-      "integrity": "sha512-BZA3QnfQGW91gYaybRmHnCAPBvQggtmHZJrAmuBZUKUS12HoQm8uybjw2fZO+vahEeUQceKNDISRcT1eLLijog==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ja": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ja/-/lang-ja-4.26.1.tgz",
-      "integrity": "sha512-QgkuJOkHguRFyfnckH2It5/Kg8zecnOMJsHxYeuDC4tBF7jL/5xqWis+679lYLsXtAkrG8+fjVcBbjyopP0KHg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "kuromoji": "^0.1.2"
-      }
-    },
-    "@nlpjs/lang-ko": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ko/-/lang-ko-4.26.1.tgz",
-      "integrity": "sha512-Q0N8bLJJ829ILWCKH1UQWPSNyuLaEURAXCawkDju4pt33DBLcpqz9IzO9dnqiFc+fjSgVzZ7WMaLT18hXZQ9vg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-lt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-lt/-/lang-lt-4.26.1.tgz",
-      "integrity": "sha512-SeYZxRhdCy+ClQNnF/u0MAtcDui/ocdk4NtgNOCuwNTNuzhN3t3rfGeArfBGmZeg1SIeBLUDE9dsTxYCv5AOEg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ms": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ms/-/lang-ms-4.26.1.tgz",
-      "integrity": "sha512-KxWBS+tFY2U8z9UrjQIqMM40npGDOskP5DcWhaEE3zuhzf3RTDYjy8sdz34jVd0fBdbPihX133h3bFibg2Cm7w==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/lang-id": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ne": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ne/-/lang-ne-4.26.1.tgz",
-      "integrity": "sha512-K3E2l+0LTESv+dO+ZTIdvNa+zwMJvvnMiFYYkKvJst6lhc8JgvGOsPxGsjJn6PDhI3wyfQu+dg3b+bnVPu4FDA==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-nl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-nl/-/lang-nl-4.26.1.tgz",
-      "integrity": "sha512-I/mP1RRbUN4BQ+8NXAl2FKaLHbb7f6S8JVjxHQ0sKHT4BgQ3+r0yO+DVcEsHg+vWRiY1Fyzh0gq0PhLVnF6HnA==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-no": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-no/-/lang-no-4.26.1.tgz",
-      "integrity": "sha512-a0CLL2c/OCzbg7J7ugyrsAksI96XhkQ3IeBbbx60o5o/9wsFNik6cPWrkpoE5xNtw7gLlAJWabwDiZXkl8Zrcw==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-pl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pl/-/lang-pl-4.26.1.tgz",
-      "integrity": "sha512-nrDXlq+TzQLE5IpXPIlFMzd8OpquvApWsouh6fmLsD9HZLZI4O3w1M4sXXLzE+9Ggu9Cy1m1QJ0/i7XCcv115g==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-pt": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-pt/-/lang-pt-4.26.1.tgz",
-      "integrity": "sha512-p6yZHaJ0e+n0avMHpdDw5PMk4HkKXjPbOMbrlg0dF+VRqChjxfH478Q423rDyzu/4MzDsIYB+p6KzL9AARKXpg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ro": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ro/-/lang-ro-4.26.1.tgz",
-      "integrity": "sha512-baUdTA0DWpDR0Tn6fxo+RDN/6gbuINLCARtHwap2UR/HKQWP2XoH/DIvcjZpwUTalr5MQjso31epcdeRRapczA==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ru": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ru/-/lang-ru-4.26.1.tgz",
-      "integrity": "sha512-NaZ2DAOGxWG2Us9IyIDs3m6vhGpUaUJRVgzzHHyX3LO3xEYjZmtnA0jEpBaTOe2PuNHThv0WCZUNn9BSurV3PA==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-sl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sl/-/lang-sl-4.26.1.tgz",
-      "integrity": "sha512-QBJwcJt+oKUpAnHKNJkLkx9Xm1n4dUPC5GPYfAXTnJZf0hNWJSY21GicdWi7Vu/qFJ3ghIqtSP8D7KIPLnibNw==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-sr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sr/-/lang-sr-4.26.1.tgz",
-      "integrity": "sha512-drH3+UqTW637uLWsnLrcp8jEKUGxV61ZgCBjNkVQNEv1/jbpSg6IqgynSY2JyhtnlV0f870KS0HvSbyo5AD4Ng==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-sv": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-sv/-/lang-sv-4.26.1.tgz",
-      "integrity": "sha512-2axkrYFC02tAlxCWeiEKISbe4dSteciP1CIggO/dZglnnLWgdF+g7kOeYMn7abCfFVSnh5vLqfDkrwnyIqt7Ag==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-ta": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-ta/-/lang-ta-4.26.1.tgz",
-      "integrity": "sha512-keeh+croa1TAirV9Fd3OQMo5IkAlTGNWTNweHbi/htYMX0MKOPYxyqg+VH2bml+57VY2aUj/WYgV/p3ATx9EfQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-th": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-th/-/lang-th-4.26.1.tgz",
-      "integrity": "sha512-2SWZhrln3rMw8/DsRc9yS5bi3qEdGfw2pq9Uejx/UYED5zvvL6kh9AiCJZT4k0wMBGEwWUV6HxJ0Pq/jOTHogg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-tl": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tl/-/lang-tl-4.26.1.tgz",
-      "integrity": "sha512-AzmLtg28tm0VXCm0Q0EY3OtA3m4oYxaqh4VX6uhB4J+PoEsIkm0py12SJxMNIsh/r98pobCumH8KH9bvHQoCAg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-tr": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-tr/-/lang-tr-4.26.1.tgz",
-      "integrity": "sha512-p30uuXvE9pZeU/5XkrQfvxRgiAOBmP3EyBFGV/+P05PEogaqbsmmtVCgCnR63yeRvVnGbToPBPjRK3OO1y4AEQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-uk": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-uk/-/lang-uk-4.26.1.tgz",
-      "integrity": "sha512-PVEvmlhvl6BL3e/Q4qjMPsnwON3cWEYvDh9dg+Si+sjD2Edu9tajolJKcQ6ZA4I8dXrld5xuXx+DEBH/uB4uWQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/lang-zh": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/lang-zh/-/lang-zh-4.26.1.tgz",
-      "integrity": "sha512-kwqeqeEgMAMvucVX9HNE1p6s/2APP23ZsS8Um/lNvtswb4gL5jjYF9kyCvRfqlPBQSWWdRv7wwcnNXOvXYkxcQ==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/language": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language/-/language-4.25.0.tgz",
-      "integrity": "sha512-tUF6QENoUQ/E26RYc32IgsttStSF9cNO4ySN+BQECn8VpjukWdwbMw073MlOLXzjfeobxa+3hCVrmPPcW+V3UA=="
-    },
-    "@nlpjs/language-min": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/language-min/-/language-min-4.25.0.tgz",
-      "integrity": "sha512-g8jtbDbqtRm+dlD/1Vnb4VWfKbKteApEGVTqIMxYkk6N/HMhvLZ5J2svrxzrB98a/HZ0fb//YBfFgymnz9Oukg=="
-    },
-    "@nlpjs/ner": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/ner/-/ner-4.27.0.tgz",
-      "integrity": "sha512-ptwkxriJdmgHSH9TfP10JQ1jviaSl2SupSFGUvTuWkuJhobQd3hbnlSq40V6XYvJNmqh9M9zEab/AKeghxYOTA==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "@nlpjs/neural": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/neural/-/neural-4.25.0.tgz",
-      "integrity": "sha512-Oz20denGiBe0DlQsS7lN4TNrATN1nXlHKc/HB6jJPegjVmgJVCugDaHwIGoV7qOWyA6F2fRRwOgD+quNT2gVpg=="
-    },
-    "@nlpjs/nlg": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlg/-/nlg-4.26.1.tgz",
-      "integrity": "sha512-PCJWiZ7464ChXXUGvjBZIFtoqkC24Oy6X63HgQrSv+63svz22Y5Cmu1MYLk77Nb+4keWv+hKhFJKDkvJoOpBVg==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1"
-      }
-    },
-    "@nlpjs/nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlp/-/nlp-4.27.0.tgz",
-      "integrity": "sha512-q6X7sY6TYVnQRZJKF/6mfLFlNA5oRYLhgQ5k3i1IBqH9lbWTAZJr31w/dCf97HXaYaj+vJp3h0ucfNumme9EIw==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/ner": "^4.27.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/slot": "^4.26.1"
-      }
-    },
-    "@nlpjs/nlu": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/nlu/-/nlu-4.27.0.tgz",
-      "integrity": "sha512-j4DUdoXS/y/Xag6ysYXx7Ve8NBmUVViUSCJhj3r49+zGyYtyVAHuVcqSej5q0tJjn0JSMT+6+ip8klON1q8ixw==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/similarity": "^4.26.1"
-      }
-    },
-    "@nlpjs/request": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/request/-/request-4.25.0.tgz",
-      "integrity": "sha512-MPVYWfFZY03WyFL7GWkUkv8tw968OXsdxFSJEvjXHzhiCe/vAlPCWbvoR+VnoQTgzLHxs/KIF6sIF2s9AzsLmQ==",
-      "requires": {
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0"
-      }
-    },
-    "@nlpjs/sentiment": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/sentiment/-/sentiment-4.26.1.tgz",
-      "integrity": "sha512-U2WmcW3w6yDDO45+Y7v5e6DPQj8e0x+RUUePPyRu2uIZmUtIKG+qCPMWnNLMmYQZoSQEFxmMMlLcGDC7tN7o3w==",
-      "requires": {
-        "@nlpjs/core": "^4.26.1",
-        "@nlpjs/language-min": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0"
-      }
-    },
-    "@nlpjs/similarity": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/similarity/-/similarity-4.26.1.tgz",
-      "integrity": "sha512-QutSBFGo/huNuz60PgqCjub0oBd9S8MLrjme33U5GzxuSvToQzXtn9/ynIia8qDm009D09VXV+LPeNE4h7yuSg=="
-    },
-    "@nlpjs/slot": {
-      "version": "4.26.1",
-      "resolved": "https://registry.npmjs.org/@nlpjs/slot/-/slot-4.26.1.tgz",
-      "integrity": "sha512-mK8EEy5O+mRGne822PIKMxHSFh8j+iC7hGJ6T31XdFsNhFEYXLI/0dmeBstZgTSKBTe27HNFgCCwuGb77u0o9w=="
-    },
-    "@nlpjs/xtables": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/@nlpjs/xtables/-/xtables-4.25.0.tgz",
-      "integrity": "sha512-+baCtMZIp+aDqODLQs8Wyyke5qUqQkL8AGWsZzwYuJV8S7xdW2+XklRnHnkFc3p3foC248TkzG5L8j9r6INOtg==",
-      "requires": {
-        "xlsx": "^0.18.0"
-      }
-    },
-    "@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
+    "@types/node": {
+      "version": "20.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.6.0.tgz",
+      "integrity": "sha512-najjVq5KN2vsH2U/xyh2opaSEz6cZMR2SetLIlxlj08nOcmPOemJmUK2o4kUzfLqfrWE0PIrNeE16XhYDd3nqg=="
     },
     "adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
-    },
-    "agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==",
       "requires": {
-        "debug": "4"
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "array-hyper-unique": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/array-hyper-unique/-/array-hyper-unique-2.1.4.tgz",
+      "integrity": "sha512-RVsGx2YpFGhGpgdkK7A0VjFQecVUCowpkQerGCsyXVRXHxccAlPPTDt9ueF/X7Zq/6z6duZ49i9WzTCzcnQygQ==",
+      "requires": {
+        "deep-eql": "= 4.0.0",
+        "lodash": "^4.17.21"
       }
     },
     "async": {
@@ -1686,15 +2030,33 @@
         "lodash": "^4.17.14"
       }
     },
+    "big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
+    },
     "bignumber.js": {
       "version": "9.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
       "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig=="
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "bmp-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
       "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
     },
     "cfb": {
       "version": "1.2.2",
@@ -1703,24 +2065,109 @@
       "requires": {
         "adler-32": "~1.3.0",
         "crc-32": "~1.2.0"
+      },
+      "dependencies": {
+        "adler-32": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
+          "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="
+        }
       }
     },
+    "chinese-parseint2": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/chinese-parseint2/-/chinese-parseint2-2.0.6.tgz",
+      "integrity": "sha512-OZNUZHJ29I4HLj1sz2m41vO2gk1xxZridWc3YW2FB6y7Mda6Si3fpPzcAFA5vst0ZQBDbBxIJxioK/FV7zrp/A=="
+    },
+    "cjk-conv": {
+      "version": "1.2.143",
+      "resolved": "https://registry.npmjs.org/cjk-conv/-/cjk-conv-1.2.143.tgz",
+      "integrity": "sha512-6t2yH0AzthiKniIjMW2VVuld7APYiGfyMnkWDPacSwzR1t7EWKNpnqwrOQz4iGp90++O10DKL8pULcn1trqlcg==",
+      "requires": {
+        "@lazy-cjk/jp-table-alias": "^1.0.41",
+        "@lazy-cjk/jp-table-comparison": "^1.0.29",
+        "@lazy-cjk/jp-table-convert": "^1.0.46",
+        "@lazy-cjk/jp-table-voice": "^1.0.37",
+        "@lazy-cjk/novel-filename": "^1.0.50",
+        "@lazy-cjk/util": "^1.0.18",
+        "@lazy-cjk/zh-convert": "^1.0.48",
+        "@lazy-cjk/zh-convert-table": "^1.0.23",
+        "@lazy-cjk/zh-slugify": "^1.0.86",
+        "@lazy-cjk/zh-table-alias": "^1.0.62",
+        "@lazy-cjk/zh-table-greedy": "^1.0.90",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "class-proxy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/class-proxy/-/class-proxy-2.0.0.tgz",
+      "integrity": "sha512-BDQfDF/EThTivmMgaEpiwToj20nDzpXoverANmY7aJyTe2z4ss8ZRlFnWFkJqcMli9HvNDzO1+getFeoED/xZg=="
+    },
     "codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
+      "integrity": "sha512-iz3zJLhlrg37/gYRWgEPkaFTtzmnEv1h+r7NgZum2lFElYQPi0/5bnmuDfODHxfp0INEfnRqyfyeIJDbb7ahRw==",
+      "requires": {
+        "commander": "~2.14.1",
+        "exit-on-epipe": "~1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+        }
+      }
+    },
+    "commander": {
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+      "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+    },
+    "core-decorators": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/core-decorators/-/core-decorators-0.20.0.tgz",
+      "integrity": "sha512-7cp/Pz3AmQXjRwhAsFN+8ndRiBNyLxtZgC/fhKvrwQTf2ZlZma6LnimoJPrOqgxZ0tIeI9VvSs+QKe0OPJ0SuA=="
     },
     "crc-32": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="
     },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+    "crlf-normalize": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/crlf-normalize/-/crlf-normalize-1.0.19.tgz",
+      "integrity": "sha512-cpV1h7YwFtIA36NHtyWuMMMPGxUp6zrzxjRnFEDLh1ZH0SPNUqCWmM8RlKVycxvKHgZOxWXs3XxX/DAlBAjFzA==",
       "requires": {
-        "ms": "2.1.2"
+        "ts-type": ">=2"
+      }
+    },
+    "deep-eql": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.0.0.tgz",
+      "integrity": "sha512-GxJC5MOg2KyQlv6WiUF/VAnMj4MWnYiXo4oLgeptOELVoknyErb4Z8+5F/IM/K4g9/80YzzatxmWcyRwUseH0A==",
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
+    },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
+    "deepmerge-plus": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/deepmerge-plus/-/deepmerge-plus-2.1.3.tgz",
+      "integrity": "sha512-nmRWdc9y7aqrhnZ1bWA+LOQuMV9WY6roWrZ7HN86l+JQ4HYRKXSQwOTNHseU88Py/knsov4j5Qh5RuFqCsNN8g==",
+      "requires": {
+        "is-mergeable-object": "1.1.0"
       }
     },
     "doublearray": {
@@ -1728,14 +2175,28 @@
       "resolved": "https://registry.npmjs.org/doublearray/-/doublearray-0.0.2.tgz",
       "integrity": "sha512-aw55FtZzT6AmiamEj2kvmR6BuFqvYgKZUkfQ7teqVRNqD5UE0rw8IeW/3gieHNKQ5sPuDKlljWEn4bzv5+1bHw=="
     },
+    "emoji-regex": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
+    },
+    "es6-class-prototype": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es6-class-prototype/-/es6-class-prototype-2.0.0.tgz",
+      "integrity": "sha512-nn4YicqIBGRYIf8n/k45/iMfEZY8VVEW3jSeKWE9UTojR2evH1nl5fsJ9Cu7ZYZGUWaqZbXDyXMHk+e8ekw7Aw==",
+      "requires": {
+        "class-proxy": "^2.0.0"
+      }
+    },
     "escodegen": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "requires": {
         "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
+        "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
         "source-map": "~0.6.1"
       }
     },
@@ -1745,43 +2206,70 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
+    },
+    "fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "frac": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
       "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
     },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
     "grapheme-splitter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="
-    },
-    "http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "requires": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
-    "https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "requires": {
-        "agent-base": "6",
-        "debug": "4"
-      }
     },
     "idb-keyval": {
       "version": "6.2.1",
@@ -1792,6 +2280,34 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
       "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-mergeable-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-mergeable-object/-/is-mergeable-object-1.1.0.tgz",
+      "integrity": "sha512-JfyDDwUdtS4yHCgUpxOyKB9dnfZ0gecufxB0eytX6BmSXSE+8dbxDGt+V7CNRIRJ9sYFV/WQt2KJG6hNob2sBw=="
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-url": {
       "version": "1.2.4",
@@ -1822,15 +2338,68 @@
         "zlibjs": "^0.3.1"
       }
     },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
+    "lodash.last": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
+      "integrity": "sha512-14mq7rSkCxG4XMy9lF2FbIOqqgF0aH0NfPuQ3LPR3vIh0kHnUvIYP70dqa1Hf47zyXfQ8FzAg0MYOQeSuE1R7A=="
+    },
+    "lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ=="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="
+    },
+    "lodash.tonumber": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.tonumber/-/lodash.tonumber-4.0.3.tgz",
+      "integrity": "sha512-SY0SwuPOHRwKcCNTdsntPYb+Zddz5mDUIVFABzRMqmAiL41pMeyoQFGxYAw5zdc9NnH4pbJqiqqp5ckfxa+zSA=="
+    },
+    "lodash.trimend": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.trimend/-/lodash.trimend-4.5.1.tgz",
+      "integrity": "sha512-lsD+k73XztDsMBKPKvzHXRKFNMohTjoTKIIo4ADLn5dA65LZ1BqlAvSXhR2rPEC3BgAUQnzMnorqDtqn2z4IHA=="
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "node-fetch": {
       "version": "2.6.12",
@@ -1841,25 +2410,47 @@
       }
     },
     "node-nlp": {
-      "version": "4.27.0",
-      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-4.27.0.tgz",
-      "integrity": "sha512-LnkhOUPXX0CMFbSzJ1gHI+7Yb3ULLip5gRsqedXb6pryjcRCbNzPgHXcH/6G9B1vSbDfO+y3X2B4QZpfP12OyQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/node-nlp/-/node-nlp-3.10.2.tgz",
+      "integrity": "sha512-xvTGtbNJNeCNX4zmhDhmyLoocRoEYPRiYBitiD6zptvUjzK9gpO3VXl08QNpKJQXNXvdUE50AecRTaDVM0i8DQ==",
       "requires": {
-        "@nlpjs/builtin-duckling": "^4.26.1",
-        "@nlpjs/builtin-microsoft": "^4.26.1",
-        "@nlpjs/core-loader": "^4.26.1",
-        "@nlpjs/emoji": "^4.26.1",
-        "@nlpjs/evaluator": "^4.26.1",
-        "@nlpjs/lang-all": "^4.26.1",
-        "@nlpjs/language": "^4.25.0",
-        "@nlpjs/neural": "^4.25.0",
-        "@nlpjs/nlg": "^4.26.1",
-        "@nlpjs/nlp": "^4.27.0",
-        "@nlpjs/nlu": "^4.27.0",
-        "@nlpjs/request": "^4.25.0",
-        "@nlpjs/sentiment": "^4.26.1",
-        "@nlpjs/similarity": "^4.26.1",
-        "@nlpjs/xtables": "^4.25.0"
+        "@microsoft/recognizers-text-suite": "1.1.4",
+        "escodegen": "^1.12.0",
+        "esprima": "^4.0.1",
+        "kuromoji": "^0.1.2",
+        "novel-segment": "^2.5.0",
+        "xlsx": "^0.15.1"
+      }
+    },
+    "novel-segment": {
+      "version": "2.7.108",
+      "resolved": "https://registry.npmjs.org/novel-segment/-/novel-segment-2.7.108.tgz",
+      "integrity": "sha512-O1WEuAhOr8KotCgX+wAuZkXlxFg/xJXhhtxVD2GhjJ7KnunCm4u2CmjbRhcuc3ABC9as/PAWTasKm7KkNT1Kyw==",
+      "requires": {
+        "@bluelovers/fast-glob": "^3.0.4",
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "@novel-segment/postag": "^1.0.26",
+        "@novel-segment/stringify": "^1.0.14",
+        "@novel-segment/table-blacklist": "^1.0.13",
+        "@novel-segment/table-core-abstract": "^1.0.16",
+        "@novel-segment/table-dict": "^1.0.16",
+        "@novel-segment/table-stopword": "^1.0.13",
+        "@novel-segment/table-synonym": "^1.0.13",
+        "@novel-segment/types": "^1.0.11",
+        "array-hyper-unique": "^2.1.4",
+        "bluebird": "^3.7.2",
+        "cjk-conv": "^1.2.143",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "deepmerge-plus": "^2.1.3",
+        "regexp-cjk": "^3.3.110",
+        "segment-dict": "^2.3.194",
+        "sort-object-keys2": "^3.0.5",
+        "str-util": "^2.3.39",
+        "ts-enum-util": "4.0.2",
+        "ts-type": "^3.0.1",
+        "tslib": ">=2",
+        "uni-string": "^2.0.5"
       }
     },
     "opencollective-postinstall": {
@@ -1867,10 +2458,167 @@
       "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
+    },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+    },
     "regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "regexp-cjk": {
+      "version": "3.3.110",
+      "resolved": "https://registry.npmjs.org/regexp-cjk/-/regexp-cjk-3.3.110.tgz",
+      "integrity": "sha512-j8xVAGrxtah6YsFOaNqg9E+XhBwblzuvqDLdIHx2j5+cwJwhWAT06sd+zt4Eht3bmrGkJskffSUtEgnXPn8lnQ==",
+      "requires": {
+        "@lazy-cjk/zh-table-list": "^1.0.84",
+        "array-hyper-unique": "^2.1.4",
+        "lodash": "^4.17.21",
+        "regexp-helper": "^1.0.37",
+        "regexp-parser-event": "^1.1.43",
+        "regexp-parser-literal": "^1.1.36",
+        "regexp-range": "^2.0.3",
+        "tslib": ">=2"
+      }
+    },
+    "regexp-helper": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/regexp-helper/-/regexp-helper-1.0.37.tgz",
+      "integrity": "sha512-ljaT9d0l9tbvAnfQad9LajUOBYOJv6dG4ERN523rzoHHtqYsTDKpUX5TrMzzR4VYB/hUKO9nrF8x8EtOyJssoA==",
+      "requires": {
+        "regexp-helper-core": "^2.0.7",
+        "regexp-support": "^1.0.52",
+        "tslib": ">=2"
+      }
+    },
+    "regexp-helper-core": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/regexp-helper-core/-/regexp-helper-core-2.0.7.tgz",
+      "integrity": "sha512-Os9hhbLSriww8+83t5JQ/ZD2kSTXliPQ0OZ5zY4OYIrNiGI9gl2mBfGW7yoLdhFobN8V8UqI4GgM5LgpaiRNjQ=="
+    },
+    "regexp-parser-event": {
+      "version": "1.1.43",
+      "resolved": "https://registry.npmjs.org/regexp-parser-event/-/regexp-parser-event-1.1.43.tgz",
+      "integrity": "sha512-yGNjt4JLfhjjW4ApnPMgCSzfWjPEFORm9m8ePjMg1LaxU194e3Jd698wqE6xgIo7A/HrrlBIELJaYK0tNugxQg==",
+      "requires": {
+        "array-hyper-unique": "^2.1.4",
+        "regexp-parser-literal": "^1.1.36",
+        "regexpp2": "^1.3.32",
+        "ts-type": ">=2",
+        "tslib": ">=2"
+      }
+    },
+    "regexp-parser-literal": {
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/regexp-parser-literal/-/regexp-parser-literal-1.1.36.tgz",
+      "integrity": "sha512-voha1jKjL9fpoX+YT/5SSTT5MqZR+X909WTA5umRdBLO1ifU2K0uJYA1EcWAh4PL2wMDH8b8Fv2Iq/Znh/eVtw==",
+      "requires": {
+        "array-hyper-unique": "^2.1.4",
+        "emoji-regex": "^10.2.1",
+        "regexpp2": "^1.3.32",
+        "tslib": ">=2",
+        "uni-string": "^2.0.2"
+      }
+    },
+    "regexp-range": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/regexp-range/-/regexp-range-2.0.3.tgz",
+      "integrity": "sha512-DdhZLQrwdEvOUSrJ6dttQYkZUr3ePn/AVacMgGpe9vRUDwGokgd5PtjryzY+DetZmo488JnEZQRWJDgKObKwMg==",
+      "requires": {
+        "@bluelovers/fill-range": "^7.0.2",
+        "@lazy-cjk/regexp-range-table": "^1.0.4",
+        "array-hyper-unique": "^2.1.4"
+      }
+    },
+    "regexp-support": {
+      "version": "1.0.52",
+      "resolved": "https://registry.npmjs.org/regexp-support/-/regexp-support-1.0.52.tgz",
+      "integrity": "sha512-xrQ04NSjNZuUycj60MavZm3johOZSpob/lOKdu2lPPM/NPXeGxqN70bl8VmlkL16Bltf760ACPGBxbpD0SE+2g==",
+      "requires": {
+        "sort-object-keys2": "^3.0.4",
+        "tslib": ">=2"
+      }
+    },
+    "regexpp2": {
+      "version": "1.3.32",
+      "resolved": "https://registry.npmjs.org/regexpp2/-/regexpp2-1.3.32.tgz",
+      "integrity": "sha512-vVwdpd23k3459hqLaEB2JeKhGM7fuuqVhWzT9ltdEXLC00yf7jcWltJxl0nM0tj2pLre90kXzJT6NvWdbc/6AA==",
+      "requires": {
+        "tslib": ">=2"
+      }
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "runes2": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/runes2/-/runes2-1.1.2.tgz",
+      "integrity": "sha512-v6XIdRpUKdFLNhgF2AC9XvntZsDzxyTpVlpQ8HD592XD6vHiW8jEcHFnTV5ztUjWJC5cGOcdi9YKIwxWVh0f9w=="
+    },
+    "segment-dict": {
+      "version": "2.3.194",
+      "resolved": "https://registry.npmjs.org/segment-dict/-/segment-dict-2.3.194.tgz",
+      "integrity": "sha512-/Pj6Z8mMm4oyzmxseRX58kt7AXOlhSjTp9A8uynnPiejJu7dsXizOi7igHlTWbA7ZDS0VWgKj2n8nv078RtZlQ==",
+      "requires": {
+        "@bluelovers/fast-glob": "^3.0.4",
+        "@novel-segment/dict-loader-core": "^1.0.28",
+        "@novel-segment/loader-stopword": "^1.0.28",
+        "@novel-segment/loaders": "^1.0.47",
+        "@novel-segment/stream-loader-core": "^1.0.24",
+        "@novel-segment/util": "^1.0.73",
+        "bluebird": "^3.7.2",
+        "core-decorators": "^0.20.0",
+        "crlf-normalize": "^1.0.19",
+        "tslib": ">=2"
+      }
+    },
+    "sort-object-keys2": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/sort-object-keys2/-/sort-object-keys2-3.0.5.tgz",
+      "integrity": "sha512-Q5fNSFbM4xXeTp1OtH62o67j+gzr2jPhZE0ES9bspDS26ScYfc2z5fL2vyRfVs947pkXCTS95Z/73lcbXuSJfg==",
+      "requires": {
+        "@lazy-array/util-unique": "^1.0.4"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -1878,12 +2626,53 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "optional": true
     },
+    "split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="
+    },
     "ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.3.tgz",
+      "integrity": "sha512-pRuUdW0WwyB2doSqqjWyzwCD6PkfxpHAHdZp39K3dp/Hq7f+xfMwNAWIi16DyrRg4gg9c/RvLYkJTSawTPTm1w==",
       "requires": {
         "frac": "~1.1.2"
+      }
+    },
+    "str-util": {
+      "version": "2.3.40",
+      "resolved": "https://registry.npmjs.org/str-util/-/str-util-2.3.40.tgz",
+      "integrity": "sha512-wbrS5y0PAh+HtO7/3AESP6wfszS1QcBymTqjg1NwnA8W5NbqznwAt7l7rmpBHOupiVHmT8XWtR7skU3Qeqk3aQ==",
+      "requires": {
+        "@lazy-cjk/japanese": "^1.2.33",
+        "chinese-parseint2": "^2.0.6",
+        "cjk-conv": ">=1",
+        "deepmerge": "^4.3.1",
+        "is-fullwidth-code-point": "<4 >=3",
+        "strip-ansi": "<7 >=6",
+        "tslib": "^2",
+        "uni-string": "^2.0.5"
+      }
+    },
+    "stream-pipe": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-pipe/-/stream-pipe-1.0.4.tgz",
+      "integrity": "sha512-B60m1SSbH4yc7CTRj46hIu7/iDboTdurqEpXgzMxZMClTl2VCegn1lMr7OK0MTnRR3ziFpr7z5t15xUP31cqlw==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "string-natural-compare2": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/string-natural-compare2/-/string-natural-compare2-3.0.1.tgz",
+      "integrity": "sha512-2g5OCprlirAeevzB1hmxas7fFhXQpAH12uJrU7/+DSSk+KRw6hO9h+XW5CwFjnzxa0FRNYvrGtb0WvXDjEME5g=="
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
       }
     },
     "tesseract.js": {
@@ -1913,10 +2702,71 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "ts-enum-util": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ts-enum-util/-/ts-enum-util-4.0.2.tgz",
+      "integrity": "sha512-BB5qjvHYgYgOB/CaoA1Cy/B2QNnZ+nVBrJ15VV/AXGWx+AO83k5wgeLOJvkSLoKKavvH/M8Wj4ZbgROjsuYwzw=="
+    },
+    "ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w==",
+      "peer": true
+    },
+    "ts-type": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ts-type/-/ts-type-3.0.1.tgz",
+      "integrity": "sha512-cleRydCkBGBFQ4KAvLH0ARIkciduS745prkGVVxPGvcRGhMMoSJUB7gNR1ByKhFTEYrYRg2CsMRGYnqp+6op+g==",
+      "requires": {
+        "@types/node": "*",
+        "tslib": ">=2",
+        "typedarray-dts": "^1.0.0"
+      }
+    },
+    "tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+    },
+    "typedarray-dts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/typedarray-dts/-/typedarray-dts-1.0.0.tgz",
+      "integrity": "sha512-Ka0DBegjuV9IPYFT1h0Qqk5U4pccebNIJCGl8C5uU7xtOs+jpJvKGAY4fHGK25hTmXZOEUl9Cnsg5cS6K/b5DA=="
+    },
+    "uni-string": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uni-string/-/uni-string-2.0.5.tgz",
+      "integrity": "sha512-P2trBOQaqy9hiBtfkpn0MxripLhQqGua1Qy9cshYlVRIChUP6SmFhILWAsRWPhsWhGAWC8ymVYXr+vOKkyWALg==",
+      "requires": {
+        "es6-class-prototype": "^2.0.0",
+        "runes2": "^1.1.2"
+      }
     },
     "wasm-feature-detect": {
       "version": "1.5.1",
@@ -1942,23 +2792,24 @@
       "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
       "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="
     },
-    "word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="
+    "word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="
     },
     "xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.15.6.tgz",
+      "integrity": "sha512-7vD9eutyLs65iDjNFimVN+gk/oDkfkCgpQUjdE82QgzJCrBHC4bGPH7fzKVyy0UPp3gyFVQTQEFJaWaAvZCShQ==",
       "requires": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
+        "adler-32": "~1.2.0",
+        "cfb": "^1.1.4",
+        "codepage": "~1.14.0",
+        "commander": "~2.17.1",
+        "crc-32": "~1.2.0",
+        "exit-on-epipe": "~1.0.1",
+        "ssf": "~0.10.3",
+        "wmf": "~1.0.1"
       }
     },
     "zlibjs": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bignumber.js": "^9.1.1",
     "JSONStream": "^1.3.5",
-    "node-nlp": "^4.27.0",
+    "node-nlp": "^3.10.2",
     "tesseract.js": "^4.1.1"
   }
 }

--- a/utils/textClassifier.js
+++ b/utils/textClassifier.js
@@ -60,7 +60,7 @@ class textClassifier {
         const language = guessLanguage(input).alpha3
         const analysis = await manager.process(language, input)
 
-        return { sentence: analysis.utterance, classification: analysis.classifications[0], triggerWords: analysisEntities }
+        return { sentence: analysis.utterance, classification: analysis.classifications[0] }
     }
 
 }


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
1. Changed version of node-nlp to a stable version
